### PR TITLE
Fix CI trigger for main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branch:
+    branches:
       - main
 
 jobs:


### PR DESCRIPTION
## Summary
- only run CI on pushes to `main`

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6872c29c39008331ae4701161caaf59e