### PR TITLE
Refactor math helpers

### DIFF
--- a/src/math.ts
+++ b/src/math.ts
@@ -1,0 +1,60 @@
+export type Vec2 = { x: number; y: number };
+
+export const vec = (x: number, y: number): Vec2 => ({ x, y });
+
+export const addVec = (a: Vec2, b: Vec2): Vec2 => ({
+	x: a.x + b.x,
+	y: a.y + b.y,
+});
+
+export const subVec = (a: Vec2, b: Vec2): Vec2 => ({
+	x: a.x - b.x,
+	y: a.y - b.y,
+});
+
+export const scaleVec = (v: Vec2, s: number): Vec2 => ({
+	x: v.x * s,
+	y: v.y * s,
+});
+
+export const lengthVec = (v: Vec2): number => Math.hypot(v.x, v.y);
+
+export const perpVec = (v: Vec2): Vec2 => ({ x: -v.y, y: v.x });
+
+export type BoundingBox2d = { start: Vec2; end: Vec2 };
+
+export const boundingBoxFromPoints = (...pts: Vec2[]): BoundingBox2d => {
+	const xs = pts.map((p) => p.x);
+	const ys = pts.map((p) => p.y);
+	return {
+		start: { x: Math.min(...xs), y: Math.min(...ys) },
+		end: { x: Math.max(...xs), y: Math.max(...ys) },
+	};
+};
+
+export const boundingBoxFromRect = (rect: {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}): BoundingBox2d =>
+	boundingBoxFromPoints(
+		vec(rect.x, rect.y),
+		vec(rect.x + rect.width, rect.y + rect.height),
+	);
+
+export function unionBoundingBox2d(
+	a: BoundingBox2d,
+	b: BoundingBox2d,
+): BoundingBox2d {
+	return {
+		start: {
+			x: Math.min(a.start.x, b.start.x),
+			y: Math.min(a.start.y, b.start.y),
+		},
+		end: {
+			x: Math.max(a.end.x, b.end.x),
+			y: Math.max(a.end.y, b.end.y),
+		},
+	};
+}

--- a/src/maths.spec.ts
+++ b/src/maths.spec.ts
@@ -1,0 +1,36 @@
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+import { unionBoundingBox2d } from "./math";
+
+describe("unionBoundingBox2d", () => {
+	const boxArb = fc
+		.tuple(
+			fc.integer({ min: -50, max: 50 }),
+			fc.integer({ min: -50, max: 50 }),
+			fc.integer({ min: -50, max: 50 }),
+			fc.integer({ min: -50, max: 50 }),
+		)
+		.map(([x1, y1, x2, y2]) => ({
+			start: { x: Math.min(x1, x2), y: Math.min(y1, y2) },
+			end: { x: Math.max(x1, x2), y: Math.max(y1, y2) },
+		}));
+
+	it("encapsulates both boxes", () => {
+		fc.assert(
+			fc.property(boxArb, boxArb, (a, b) => {
+				const combined = unionBoundingBox2d(a, b);
+				const expected = {
+					start: {
+						x: Math.min(a.start.x, b.start.x),
+						y: Math.min(a.start.y, b.start.y),
+					},
+					end: {
+						x: Math.max(a.end.x, b.end.x),
+						y: Math.max(a.end.y, b.end.y),
+					},
+				};
+				expect(combined).toStrictEqual(expected);
+			}),
+		);
+	});
+});

--- a/src/output.spec.ts
+++ b/src/output.spec.ts
@@ -1,6 +1,5 @@
-import fc from "fast-check";
 import { describe, expect, it } from "vitest";
-import { layoutToSvg, unionBoundingBox2d } from "./output";
+import { layoutToSvg } from "./output";
 import type { LayoutResult, NodeRecord } from "./solver";
 
 describe("layoutToSvg", () => {
@@ -93,38 +92,5 @@ describe("layoutToSvg", () => {
 		expect(svg).toContain("<polygon");
 		expect(svg).not.toContain("marker-end");
 		expect(svg).toContain('stroke-width="3"');
-	});
-});
-
-describe("unionBoundingBox2d", () => {
-	const boxArb = fc
-		.tuple(
-			fc.integer({ min: -50, max: 50 }),
-			fc.integer({ min: -50, max: 50 }),
-			fc.integer({ min: -50, max: 50 }),
-			fc.integer({ min: -50, max: 50 }),
-		)
-		.map(([x1, y1, x2, y2]) => ({
-			start: { x: Math.min(x1, x2), y: Math.min(y1, y2) },
-			end: { x: Math.max(x1, x2), y: Math.max(y1, y2) },
-		}));
-
-	it("encapsulates both boxes", () => {
-		fc.assert(
-			fc.property(boxArb, boxArb, (a, b) => {
-				const combined = unionBoundingBox2d(a, b);
-				const expected = {
-					start: {
-						x: Math.min(a.start.x, b.start.x),
-						y: Math.min(a.start.y, b.start.y),
-					},
-					end: {
-						x: Math.max(a.end.x, b.end.x),
-						y: Math.max(a.end.y, b.end.y),
-					},
-				};
-				expect(combined).toStrictEqual(expected);
-			}),
-		);
 	});
 });

--- a/src/output.ts
+++ b/src/output.ts
@@ -1,65 +1,17 @@
+import {
+	addVec,
+	type BoundingBox2d,
+	boundingBoxFromPoints,
+	boundingBoxFromRect,
+	lengthVec,
+	perpVec,
+	scaleVec,
+	subVec,
+	unionBoundingBox2d,
+	type Vec2,
+	vec,
+} from "./math";
 import type { LayoutResult, NodeRecord } from "./solver";
-
-export type Vec2 = { x: number; y: number };
-
-export const vec = (x: number, y: number): Vec2 => ({ x, y });
-
-export const addVec = (a: Vec2, b: Vec2): Vec2 => ({
-	x: a.x + b.x,
-	y: a.y + b.y,
-});
-
-export const subVec = (a: Vec2, b: Vec2): Vec2 => ({
-	x: a.x - b.x,
-	y: a.y - b.y,
-});
-
-export const scaleVec = (v: Vec2, s: number): Vec2 => ({
-	x: v.x * s,
-	y: v.y * s,
-});
-
-export const lengthVec = (v: Vec2): number => Math.hypot(v.x, v.y);
-
-export const perpVec = (v: Vec2): Vec2 => ({ x: -v.y, y: v.x });
-
-export type BoundingBox2d = { start: Vec2; end: Vec2 };
-
-export const boundingBoxFromPoints = (...pts: Vec2[]): BoundingBox2d => {
-	const xs = pts.map((p) => p.x);
-	const ys = pts.map((p) => p.y);
-	return {
-		start: { x: Math.min(...xs), y: Math.min(...ys) },
-		end: { x: Math.max(...xs), y: Math.max(...ys) },
-	};
-};
-
-export const boundingBoxFromRect = (rect: {
-	x: number;
-	y: number;
-	width: number;
-	height: number;
-}): BoundingBox2d =>
-	boundingBoxFromPoints(
-		vec(rect.x, rect.y),
-		vec(rect.x + rect.width, rect.y + rect.height),
-	);
-
-export function unionBoundingBox2d(
-	a: BoundingBox2d,
-	b: BoundingBox2d,
-): BoundingBox2d {
-	return {
-		start: {
-			x: Math.min(a.start.x, b.start.x),
-			y: Math.min(a.start.y, b.start.y),
-		},
-		end: {
-			x: Math.max(a.end.x, b.end.x),
-			y: Math.max(a.end.y, b.end.y),
-		},
-	};
-}
 
 export function layoutBounds(
 	layout: LayoutResult,


### PR DESCRIPTION
## Summary
- move common geometry helpers to `src/math.ts`
- adjust output code to use new math module
- split property test into `maths.spec.ts`

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6872c36ca5908331aa6fcb4c05730833