### PR TITLE
Refactor CLI with commander

### DIFF
--- a/bin/modular-svg
+++ b/bin/modular-svg
@@ -1,18 +1,16 @@
 #!/usr/bin/env bun
-import { readFileSync, writeFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
+import { readFile, writeFile } from "node:fs/promises";
+import { Command } from "commander";
 import {
-       buildSceneFromJson,
-       layoutToSvg,
-       solveLayout,
-       validate,
+        buildSceneFromJson,
+        layoutToSvg,
+        solveLayout,
+        validate,
 } from "../src/index.ts";
 
-
-async function readInput(arg) {
+async function readInput(arg?: string): Promise<string> {
         if (arg && arg !== "-") {
-                return readFileSync(arg, "utf8");
+                return await readFile(arg, "utf8");
         }
         if (process.stdin.isTTY) {
                 console.error("Usage: modular-svg <scene.json|-> [output.svg|-]");
@@ -23,44 +21,32 @@ async function readInput(arg) {
         return data;
 }
 
-try {
-        let margin = 3;
-        const args = process.argv.slice(2);
-        const files = [];
-        for (let i = 0; i < args.length; i++) {
-                const arg = args[i];
-                if (arg === "-m" || arg === "--margin") {
-                        const val = args[i + 1];
-                        margin = val ? Number(val) : margin;
-                        i++;
-                        continue;
+const program = new Command();
+program
+        .name("modular-svg")
+        .argument("[input]", "scene JSON file or '-' to read from stdin")
+        .argument("[output]", "output SVG file or '-' for stdout")
+        .option("-m, --margin <number>", "margin around the SVG", "3")
+        .action(async (input: string | undefined, output: string | undefined, opts) => {
+                const raw = await readInput(input);
+                const data = JSON.parse(raw);
+                try {
+                        validate(data);
+                } catch (err) {
+                        console.error("Invalid scene:", err);
+                        process.exit(1);
                 }
-                const match = /^--margin=(.*)$/.exec(arg);
-                if (match) {
-                        margin = Number(match[1]);
-                        continue;
+                const scene = buildSceneFromJson(data);
+                const layout = solveLayout(scene);
+                const svg = layoutToSvg(layout, scene.nodes, Number(opts.margin));
+                if (output && output !== "-") {
+                       await writeFile(output, svg);
+                } else {
+                        process.stdout.write(svg);
                 }
-                files.push(arg);
-        }
-        const inputArg = files[0];
-        const raw = await readInput(inputArg);
-        const data = JSON.parse(raw);
-        try {
-                validate(data);
-        } catch (err) {
-                console.error("Invalid scene:", err);
-                process.exit(1);
-        }
-        const scene = buildSceneFromJson(data);
-        const layout = solveLayout(scene);
-        const svg = layoutToSvg(layout, scene.nodes, margin);
-        const out = files[1];
-        if (out && out !== "-") {
-                writeFileSync(out, svg);
-        } else {
-                process.stdout.write(svg);
-        }
-} catch (err) {
+        });
+
+program.parseAsync(process.argv).catch((err) => {
         console.error(err);
         process.exit(1);
-}
+});

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
 	},
 	"packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0",
 	"dependencies": {
-		"ajv": "^8.17.1"
+		"ajv": "^8.17.1",
+		"commander": "^14.0.0"
 	},
 	"type": "module"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       ajv:
         specifier: ^8.17.1
         version: 8.17.1
+      commander:
+        specifier: ^14.0.0
+        version: 14.0.0
     devDependencies:
       '@biomejs/biome':
         specifier: 2.1.1
@@ -404,6 +407,10 @@ packages:
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
     engines: {node: '>= 16'}
+
+  commander@14.0.0:
+    resolution: {integrity: sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==}
+    engines: {node: '>=20'}
 
   debug@4.4.1:
     resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
@@ -898,6 +905,8 @@ snapshots:
 
   check-error@2.1.1: {}
 
+  commander@14.0.0: {}
+
   debug@4.4.1:
     dependencies:
       ms: 2.1.3
@@ -959,6 +968,7 @@ snapshots:
   get-tsconfig@4.10.1:
     dependencies:
       resolve-pkg-maps: 1.0.0
+    optional: true
 
   husky@9.1.7: {}
 
@@ -994,7 +1004,8 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  resolve-pkg-maps@1.0.0: {}
+  resolve-pkg-maps@1.0.0:
+    optional: true
 
   rollup@4.45.0:
     dependencies:
@@ -1055,6 +1066,7 @@ snapshots:
       get-tsconfig: 4.10.1
     optionalDependencies:
       fsevents: 2.3.3
+    optional: true
 
   typescript@5.8.3: {}
 


### PR DESCRIPTION
## Summary
- use `commander` for argument parsing in the `modular-svg` CLI
- add `commander` dependency
- switch to async read/write with `node:fs/promises`
- await the `readFile` in `readInput`

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6872c3108da483318e2d8e9617d6d915