### PR TITLE
Fix typecheck by excluding docs

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -67,5 +67,6 @@
 		/* Completeness */
 		// "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
 		"skipLibCheck": true
-	}
+	},
+	"exclude": ["docs"]
 }


### PR DESCRIPTION
## Summary
- prevent docs from being included in the root TypeScript project

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6872d43e8fa48331a24ab283a910edf6