### PR TITLE
Update node to v26, drop corepack for mise-managed pnpm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,6 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@v2
 
-      - name: Enable corepack
-        run: corepack enable && mise reshim
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,6 @@
 [tools]
-node = "24"
+node = "26"
+pnpm = "9.15.4"
 bun = "latest"
 
 [tasks.setup-hooks]

--- a/package.json
+++ b/package.json
@@ -11,11 +11,10 @@
 	"license": "MIT",
 	"devDependencies": {
 		"@biomejs/biome": "2.5.2",
-		"@types/node": "^24.10.11",
+		"@types/node": "^26.1.1",
 		"typescript": "^6.0.3",
 		"vitest": "^4.1.10"
 	},
-	"packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0",
 	"dependencies": {
 		"commander": "^15.0.0"
 	},

--- a/packages/modular-svg-core/package.json
+++ b/packages/modular-svg-core/package.json
@@ -19,7 +19,7 @@
 		"ajv": "^8.20.0"
 	},
 	"devDependencies": {
-		"@types/node": "^24.10.11",
+		"@types/node": "^26.1.1",
 		"fast-check": "^4.8.0",
 		"typescript": "^6.0.3",
 		"vitest": "^4.1.10"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,14 +16,14 @@ importers:
         specifier: 2.5.2
         version: 2.5.2
       '@types/node':
-        specifier: ^24.10.11
-        version: 24.13.3
+        specifier: ^26.1.1
+        version: 26.1.1
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.1.3(@types/node@24.13.3)(tsx@4.20.3))
+        version: 4.1.10(@types/node@26.1.1)(jsdom@29.1.1)(vite@8.1.3(@types/node@26.1.1)(tsx@4.20.3))
 
   packages/modular-svg-core:
     dependencies:
@@ -32,8 +32,8 @@ importers:
         version: 8.20.0
     devDependencies:
       '@types/node':
-        specifier: ^24.10.11
-        version: 24.13.3
+        specifier: ^26.1.1
+        version: 26.1.1
       fast-check:
         specifier: ^4.8.0
         version: 4.8.0
@@ -42,7 +42,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.1.3(@types/node@24.13.3)(tsx@4.20.3))
+        version: 4.1.10(@types/node@26.1.1)(jsdom@29.1.1)(vite@8.1.3(@types/node@26.1.1)(tsx@4.20.3))
 
   packages/modular-svg-react:
     dependencies:
@@ -566,9 +566,6 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
-  '@types/node@24.13.3':
-    resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
-
   '@types/node@26.1.1':
     resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
 
@@ -994,9 +991,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@7.18.2:
-    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
-
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
@@ -1412,14 +1406,9 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
-  '@types/node@24.13.3':
-    dependencies:
-      undici-types: 7.18.2
-
   '@types/node@26.1.1':
     dependencies:
       undici-types: 8.3.0
-    optional: true
 
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
@@ -1450,14 +1439,6 @@ snapshots:
       '@vitest/utils': 4.1.10
       chai: 6.2.2
       tinyrainbow: 3.1.0
-
-  '@vitest/mocker@4.1.10(vite@8.1.3(@types/node@24.13.3)(tsx@4.20.3))':
-    dependencies:
-      '@vitest/spy': 4.1.10
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 8.1.3(@types/node@24.13.3)(tsx@4.20.3)
 
   '@vitest/mocker@4.1.10(vite@8.1.3(@types/node@26.1.1)(tsx@4.20.3))':
     dependencies:
@@ -1839,24 +1820,9 @@ snapshots:
 
   typescript@6.0.3: {}
 
-  undici-types@7.18.2: {}
-
-  undici-types@8.3.0:
-    optional: true
+  undici-types@8.3.0: {}
 
   undici@7.28.0: {}
-
-  vite@8.1.3(@types/node@24.13.3)(tsx@4.20.3):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.5
-      postcss: 8.5.16
-      rolldown: 1.1.4
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 24.13.3
-      fsevents: 2.3.3
-      tsx: 4.20.3
 
   vite@8.1.3(@types/node@26.1.1)(tsx@4.20.3):
     dependencies:
@@ -1869,34 +1835,6 @@ snapshots:
       '@types/node': 26.1.1
       fsevents: 2.3.3
       tsx: 4.20.3
-
-  vitest@4.1.10(@types/node@24.13.3)(jsdom@29.1.1)(vite@8.1.3(@types/node@24.13.3)(tsx@4.20.3)):
-    dependencies:
-      '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@24.13.3)(tsx@4.20.3))
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/runner': 4.1.10
-      '@vitest/snapshot': 4.1.10
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
-      es-module-lexer: 2.3.0
-      expect-type: 1.4.0
-      magic-string: 0.30.21
-      obug: 2.1.3
-      pathe: 2.0.3
-      picomatch: 4.0.5
-      std-env: 4.2.0
-      tinybench: 2.9.0
-      tinyexec: 1.2.4
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.1.3(@types/node@24.13.3)(tsx@4.20.3)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 24.13.3
-      jsdom: 29.1.1
-    transitivePeerDependencies:
-      - msw
 
   vitest@4.1.10(@types/node@26.1.1)(jsdom@29.1.1)(vite@8.1.3(@types/node@26.1.1)(tsx@4.20.3)):
     dependencies:


### PR DESCRIPTION
- mise.toml: node 24 → 26 (currently resolves to 26.4.0), pnpm 9.15.4 added back as a mise tool
- @types/node bumped from 24.x to ^26.1.1 now that the runtime matches
- Node ≥ 25 no longer bundles corepack (removed from the distribution by the Node TSC), so pnpm is managed by mise again. The corepack CI step and the `packageManager` field are removed — mise.toml is the single source of truth for the pnpm version.

All tests, typecheck, and lint pass locally under node 26.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)