### PR TITLE
Better core tests: property-based fuzzing + Bluefish parity suite

### DIFF
--- a/packages/bluefish-parity/package.json
+++ b/packages/bluefish-parity/package.json
@@ -1,0 +1,18 @@
+{
+	"private": true,
+	"name": "@modular-svg/bluefish-parity",
+	"description": "Compares modular-svg layout output against real Bluefish rendered headlessly",
+	"type": "module",
+	"scripts": {
+		"test": "vitest run",
+		"typecheck": "tsc --noEmit"
+	},
+	"devDependencies": {
+		"@modular-svg/core": "workspace:*",
+		"@types/jsdom": "^27.0.0",
+		"bluefish-js": "0.0.39",
+		"jsdom": "^29.1.1",
+		"typescript": "^6.0.3",
+		"vitest": "^4.1.10"
+	}
+}

--- a/packages/bluefish-parity/src/bluefish-env.ts
+++ b/packages/bluefish-parity/src/bluefish-env.ts
@@ -1,0 +1,74 @@
+// Patches that must be in place BEFORE bluefish-js is imported.
+//
+// bluefish-js ships a self-contained browser bundle (Solid client runtime,
+// paper.js, text measurement) that touches DOM APIs at module scope. Under
+// vitest's jsdom environment three things are missing or wrong:
+//
+// 1. paper.js sniffs the user agent; "jsdom" is mapped to node and triggers a
+//    broken node-canvas require inside the bundle. Pretend to be Chrome.
+// 2. Text measurement uses canvas 2D measureText with actualBoundingBox* and
+//    fontBoundingBox* metrics; jsdom has no 2D context. Stub deterministic
+//    metrics (0.6em per character) so text layout is reproducible.
+// 3. Bluefish's Text measures words via SVG getComputedTextLength, which
+//    jsdom doesn't implement. Same deterministic metric.
+
+Object.defineProperty(window.navigator, "userAgent", {
+	value:
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36",
+	configurable: true,
+});
+
+(
+	window.SVGElement.prototype as unknown as {
+		getComputedTextLength: () => number;
+	}
+).getComputedTextLength = function (this: SVGElement) {
+	const fontSize = Number.parseFloat(
+		(this as unknown as { style?: { fontSize?: string } }).style?.fontSize ||
+			this.getAttribute?.("font-size") ||
+			"14",
+	);
+	return (this.textContent ?? "").length * fontSize * 0.6;
+};
+
+const origGetContext = window.HTMLCanvasElement.prototype.getContext;
+window.HTMLCanvasElement.prototype.getContext = function (
+	this: HTMLCanvasElement,
+	type: string,
+	// biome-ignore lint/suspicious/noExplicitAny: matching the DOM signature
+): any {
+	if (type !== "2d")
+		return (origGetContext as (t: string) => unknown)?.call(this, type) ?? null;
+	const base = {
+		font: "",
+		textBaseline: "alphabetic",
+		canvas: this,
+		measureText(text: string) {
+			const fontSize = Number.parseFloat(
+				/(\d+(?:\.\d+)?)px/.exec(this.font)?.[1] ?? "14",
+			);
+			const width = text.length * fontSize * 0.6;
+			return {
+				width,
+				actualBoundingBoxLeft: 0,
+				actualBoundingBoxRight: width,
+				actualBoundingBoxAscent: fontSize * 0.7,
+				actualBoundingBoxDescent: fontSize * 0.2,
+				fontBoundingBoxAscent: fontSize * 0.8,
+				fontBoundingBoxDescent: fontSize * 0.2,
+			};
+		},
+	};
+	// Everything else (save, restore, clearRect, ... used by bundled paper.js)
+	// is a no-op.
+	return new Proxy(base, {
+		get(target, prop) {
+			if (prop in target) return target[prop as keyof typeof target];
+			return () => undefined;
+		},
+		set(target, prop, value) {
+			(target as Record<string | symbol, unknown>)[prop] = value;
+			return true;
+		},
+	});
+};

--- a/packages/bluefish-parity/src/harness.ts
+++ b/packages/bluefish-parity/src/harness.ts
@@ -1,0 +1,166 @@
+import { buildSceneFromJson, solveLayout } from "@modular-svg/core";
+
+// A normalized shape: x/y is always the top-left of the bounding box so
+// circles and rects compare uniformly across both systems.
+export type Shape = {
+	kind: "circle" | "rect";
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+};
+
+// ---------------------------------------------------------------------------
+// Bluefish side
+// ---------------------------------------------------------------------------
+
+// bluefish-js touches the DOM at module scope, so it must be imported after
+// the patches in bluefish-env.ts have run (setupFiles guarantee that).
+export type BluefishModule = typeof import("bluefish-js");
+
+let bluefishModule: BluefishModule | undefined;
+
+export async function bluefish(): Promise<BluefishModule> {
+	if (!bluefishModule) bluefishModule = await import("bluefish-js");
+	return bluefishModule;
+}
+
+function parseTranslate(el: Element): { tx: number; ty: number } {
+	const t = el.getAttribute("transform");
+	if (!t) return { tx: 0, ty: 0 };
+	const m = /translate\(\s*(-?[\d.eE+-]+)(?:[ ,]+(-?[\d.eE+-]+))?\s*\)/.exec(t);
+	if (!m) return { tx: 0, ty: 0 };
+	return {
+		tx: Number.parseFloat(m[1]),
+		ty: m[2] ? Number.parseFloat(m[2]) : 0,
+	};
+}
+
+function collectShapes(el: Element, tx: number, ty: number, out: Shape[]) {
+	const { tx: dx, ty: dy } = parseTranslate(el);
+	const ax = tx + dx;
+	const ay = ty + dy;
+	const tag = el.tagName.toLowerCase();
+	if (tag === "circle") {
+		const cx = Number.parseFloat(el.getAttribute("cx") ?? "0") + ax;
+		const cy = Number.parseFloat(el.getAttribute("cy") ?? "0") + ay;
+		const r = Number.parseFloat(el.getAttribute("r") ?? "0");
+		out.push({
+			kind: "circle",
+			x: cx - r,
+			y: cy - r,
+			width: r * 2,
+			height: r * 2,
+		});
+	} else if (tag === "rect") {
+		out.push({
+			kind: "rect",
+			x: Number.parseFloat(el.getAttribute("x") ?? "0") + ax,
+			y: Number.parseFloat(el.getAttribute("y") ?? "0") + ay,
+			width: Number.parseFloat(el.getAttribute("width") ?? "0"),
+			height: Number.parseFloat(el.getAttribute("height") ?? "0"),
+		});
+	}
+	for (const child of Array.from(el.children)) {
+		collectShapes(child, ax, ay, out);
+	}
+}
+
+// Render a Bluefish diagram headlessly and return its shapes in absolute
+// coordinates (ancestor translate() transforms accumulated onto the leaves).
+export async function renderBluefish(
+	diagram: (bf: BluefishModule) => unknown,
+): Promise<Shape[]> {
+	const bf = await bluefish();
+	const app = document.createElement("div");
+	document.body.appendChild(app);
+	// Layout is synchronous; the SVG is complete when render() returns.
+	const dispose = bf.render(() => diagram(bf) as never, app);
+	try {
+		const svg = app.querySelector("svg");
+		if (!svg) throw new Error("bluefish did not render an <svg>");
+		const shapes: Shape[] = [];
+		collectShapes(svg, 0, 0, shapes);
+		return shapes;
+	} finally {
+		dispose();
+		app.remove();
+	}
+}
+
+// ---------------------------------------------------------------------------
+// modular-svg side
+// ---------------------------------------------------------------------------
+
+// Solve a JSON scene and return its drawable shapes straight from the layout
+// (bypassing SVG margin translation and stroke inflation, which are
+// presentation concerns, not layout).
+export function renderModular(json: Record<string, unknown>): Shape[] {
+	const scene = buildSceneFromJson(json);
+	const layout = solveLayout(scene);
+	const shapes: Shape[] = [];
+	for (const n of scene.nodes) {
+		if (n.type !== "rect" && n.type !== "circle") continue;
+		const box = layout[n.id];
+		shapes.push({
+			kind: n.type,
+			x: box.x,
+			y: box.y,
+			width: box.width,
+			height: box.height,
+		});
+	}
+	return shapes;
+}
+
+// ---------------------------------------------------------------------------
+// Comparison
+// ---------------------------------------------------------------------------
+
+// Both systems anchor content differently (Bluefish keeps owned positions,
+// modular-svg's solver has its own anchors), so compare geometry relative to
+// the top-left corner of the union of all shapes.
+export function normalize(shapes: Shape[]): Shape[] {
+	const minX = Math.min(...shapes.map((s) => s.x));
+	const minY = Math.min(...shapes.map((s) => s.y));
+	return shapes
+		.map((s) => ({ ...s, x: s.x - minX, y: s.y - minY }))
+		.sort(
+			(a, b) =>
+				a.kind.localeCompare(b.kind) ||
+				a.x - b.x ||
+				a.y - b.y ||
+				a.width - b.width,
+		);
+}
+
+export function expectShapesToMatch(
+	actual: Shape[],
+	reference: Shape[],
+	tolerance = 0.01,
+): void {
+	const a = normalize(actual);
+	const b = normalize(reference);
+	if (a.length !== b.length) {
+		throw new Error(
+			`shape count mismatch: modular-svg=${a.length} bluefish=${b.length}\n` +
+				`modular-svg: ${JSON.stringify(a)}\nbluefish: ${JSON.stringify(b)}`,
+		);
+	}
+	for (let i = 0; i < a.length; i++) {
+		for (const key of ["kind", "x", "y", "width", "height"] as const) {
+			const av = a[i][key];
+			const bv = b[i][key];
+			const ok =
+				typeof av === "string"
+					? av === bv
+					: Math.abs((av as number) - (bv as number)) <= tolerance;
+			if (!ok) {
+				throw new Error(
+					`shape ${i} differs on ${key}: modular-svg=${av} bluefish=${bv}\n` +
+						`modular-svg: ${JSON.stringify(a[i])}\nbluefish: ${JSON.stringify(b[i])}`,
+				);
+			}
+		}
+	}
+}

--- a/packages/bluefish-parity/src/parity.spec.ts
+++ b/packages/bluefish-parity/src/parity.spec.ts
@@ -1,0 +1,375 @@
+import { describe, expect, it } from "vitest";
+import {
+	expectShapesToMatch,
+	renderBluefish,
+	renderModular,
+} from "./harness.ts";
+
+// Geometry parity against real Bluefish (bluefishjs.org), rendered headlessly.
+// Shapes are compared relative to the union bounding box, with tolerance for
+// the damped fixed-point solver.
+//
+// Known, deliberate differences not covered here:
+// - Text geometry: Bluefish measures real font metrics (stubbed to 0.6em/char
+//   in this harness); modular-svg uses 8px/char. Text is excluded from
+//   geometry fixtures.
+// - Distribute without spacing: Bluefish throws, modular-svg spreads evenly
+//   between the outermost children (an extension).
+// - Arrows: Bluefish uses perfect-arrows; modular-svg draws a plain
+//   line + polygon head.
+
+const planetCircles = [
+	{ r: 15, fill: "#EBE3CF" },
+	{ r: 36, fill: "#DC933C" },
+	{ r: 38, fill: "#179DD7" },
+	{ r: 21, fill: "#F1CF8E" },
+];
+
+describe("stack parity", () => {
+	it("StackH of circles with explicit spacing (planets row)", async () => {
+		const reference = await renderBluefish((bf) =>
+			bf.StackH(
+				{ spacing: 50 },
+				planetCircles.map((c) => bf.Circle({ ...c, "stroke-width": 3 })),
+			),
+		);
+		const actual = renderModular({
+			type: "StackH",
+			id: "planets",
+			props: { spacing: 50 },
+			children: planetCircles.map((c, i) => ({
+				type: "Circle",
+				id: `p${i}`,
+				props: c,
+			})),
+		});
+		expectShapesToMatch(actual, reference);
+	});
+
+	it("StackH with default spacing and alignment", async () => {
+		const rects = [
+			{ width: 30, height: 10 },
+			{ width: 10, height: 40 },
+			{ width: 25, height: 25 },
+		];
+		const reference = await renderBluefish((bf) =>
+			bf.StackH(
+				{},
+				rects.map((r) => bf.Rect(r)),
+			),
+		);
+		const actual = renderModular({
+			type: "StackH",
+			id: "s",
+			children: rects.map((r, i) => ({ type: "Rect", id: `r${i}`, props: r })),
+		});
+		expectShapesToMatch(actual, reference);
+	});
+
+	for (const alignment of ["left", "centerX", "right"] as const) {
+		it(`StackV alignment ${alignment}`, async () => {
+			const rects = [
+				{ width: 30, height: 10 },
+				{ width: 10, height: 40 },
+				{ width: 60, height: 25 },
+			];
+			const reference = await renderBluefish((bf) =>
+				bf.StackV(
+					{ spacing: 7, alignment },
+					rects.map((r) => bf.Rect(r)),
+				),
+			);
+			const actual = renderModular({
+				type: "StackV",
+				id: "s",
+				props: { spacing: 7, alignment },
+				children: rects.map((r, i) => ({
+					type: "Rect",
+					id: `r${i}`,
+					props: r,
+				})),
+			});
+			expectShapesToMatch(actual, reference);
+		});
+	}
+
+	for (const alignment of ["top", "centerY", "bottom"] as const) {
+		it(`StackH alignment ${alignment}`, async () => {
+			const rects = [
+				{ width: 30, height: 10 },
+				{ width: 10, height: 40 },
+				{ width: 60, height: 25 },
+			];
+			const reference = await renderBluefish((bf) =>
+				bf.StackH(
+					{ spacing: 13, alignment },
+					rects.map((r) => bf.Rect(r)),
+				),
+			);
+			const actual = renderModular({
+				type: "StackH",
+				id: "s",
+				props: { spacing: 13, alignment },
+				children: rects.map((r, i) => ({
+					type: "Rect",
+					id: `r${i}`,
+					props: r,
+				})),
+			});
+			expectShapesToMatch(actual, reference);
+		});
+	}
+});
+
+describe("background parity", () => {
+	it("Background with default padding around a stack", async () => {
+		const reference = await renderBluefish((bf) =>
+			bf.Background(
+				{},
+				bf.StackH(
+					{ spacing: 20 },
+					planetCircles.map((c) => bf.Circle(c)),
+				),
+			),
+		);
+		const actual = renderModular({
+			type: "Background",
+			id: "bg",
+			children: [
+				{
+					type: "StackH",
+					id: "s",
+					props: { spacing: 20 },
+					children: planetCircles.map((c, i) => ({
+						type: "Circle",
+						id: `p${i}`,
+						props: c,
+					})),
+				},
+			],
+		});
+		expectShapesToMatch(actual, reference);
+	});
+
+	it("Background with explicit padding", async () => {
+		const reference = await renderBluefish((bf) =>
+			bf.Background(
+				{ padding: 40 },
+				bf.StackH(
+					{ spacing: 50 },
+					planetCircles.map((c) => bf.Circle(c)),
+				),
+			),
+		);
+		const actual = renderModular({
+			type: "Background",
+			id: "bg",
+			props: { padding: 40 },
+			children: [
+				{
+					type: "StackH",
+					id: "s",
+					props: { spacing: 50 },
+					children: planetCircles.map((c, i) => ({
+						type: "Circle",
+						id: `p${i}`,
+						props: c,
+					})),
+				},
+			],
+		});
+		expectShapesToMatch(actual, reference);
+	});
+});
+
+describe("relational parity (align + distribute over refs)", () => {
+	it("distribute horizontal with spacing", async () => {
+		const reference = await renderBluefish((bf) =>
+			bf.Distribute({ direction: "horizontal", spacing: 24 }, [
+				bf.Rect({ width: 30, height: 10, x: 0, y: 0 }),
+				bf.Rect({ width: 20, height: 20 }),
+			]),
+		);
+		const actual = renderModular({
+			type: "Group",
+			id: "root",
+			children: [
+				{
+					type: "Rect",
+					id: "a",
+					props: { width: 30, height: 10, x: 0, y: 0 },
+				},
+				{ type: "Rect", id: "b", props: { width: 20, height: 20 } },
+				{
+					type: "Distribute",
+					id: "d",
+					props: { axis: "x", spacing: 24 },
+					children: [
+						{ type: "Ref", target: "a" },
+						{ type: "Ref", target: "b" },
+					],
+				},
+			],
+		});
+		expectShapesToMatch(actual, reference);
+	});
+
+	it("the planets tutorial pattern: background + stack + align + distribute", async () => {
+		// The original Bluefish planets tutorial, with the text label replaced
+		// by a rect so text metrics stay out of the comparison.
+		const reference = await renderBluefish((bf) => [
+			bf.Background(
+				{ padding: 40 },
+				bf.StackH(
+					{ spacing: 50 },
+					planetCircles.map((c, i) =>
+						bf.Circle({ ...c, name: i === 0 ? "mercury" : `p${i}` }),
+					),
+				),
+			),
+			bf.Align({ alignment: "centerX" }, [
+				bf.Rect({ name: "label", width: 20, height: 10 }),
+				bf.Ref({ select: "mercury" }),
+			]),
+			bf.Distribute({ direction: "vertical", spacing: 60 }, [
+				bf.Ref({ select: "label" }),
+				bf.Ref({ select: "mercury" }),
+			]),
+		]);
+		const actual = renderModular({
+			type: "Group",
+			id: "root",
+			children: [
+				{
+					type: "Background",
+					id: "bg",
+					props: { padding: 40 },
+					children: [
+						{
+							type: "StackH",
+							id: "planets",
+							props: { spacing: 50 },
+							children: planetCircles.map((c, i) => ({
+								type: "Circle",
+								id: i === 0 ? "mercury" : `p${i}`,
+								props: c,
+							})),
+						},
+					],
+				},
+				{ type: "Rect", id: "label", props: { width: 20, height: 10 } },
+				{
+					type: "Align",
+					id: "al",
+					props: { axis: "x", alignment: "center" },
+					children: [
+						{ type: "Ref", target: "label" },
+						{ type: "Ref", target: "mercury" },
+					],
+				},
+				{
+					type: "Distribute",
+					id: "di",
+					props: { axis: "y", spacing: 60 },
+					children: [
+						{ type: "Ref", target: "label" },
+						{ type: "Ref", target: "mercury" },
+					],
+				},
+			],
+		});
+		expectShapesToMatch(actual, reference);
+	});
+});
+
+describe("known divergences (fixtures flip to failing when fixed)", () => {
+	// Bluefish gives every container a relative coordinate frame, so nesting
+	// composes. modular-svg's stack operators write absolute coordinates
+	// anchored at the origin, so the children of a nested stack detach from
+	// where the outer stack places their container.
+	it.fails("nested stacks compose", async () => {
+		const reference = await renderBluefish((bf) =>
+			bf.StackV({ spacing: 10, alignment: "left" }, [
+				bf.Rect({ width: 20, height: 10 }),
+				bf.StackH({ spacing: 5, alignment: "top" }, [
+					bf.Rect({ width: 30, height: 10 }),
+					bf.Rect({ width: 10, height: 20 }),
+				]),
+			]),
+		);
+		const actual = renderModular({
+			type: "StackV",
+			id: "outer",
+			props: { spacing: 10, alignment: "left" },
+			children: [
+				{ type: "Rect", id: "a", props: { width: 20, height: 10 } },
+				{
+					type: "StackH",
+					id: "inner",
+					props: { spacing: 5, alignment: "top" },
+					children: [
+						{ type: "Rect", id: "b", props: { width: 30, height: 10 } },
+						{ type: "Rect", id: "c", props: { width: 10, height: 20 } },
+					],
+				},
+			],
+		});
+		expect(actual.length).toBe(reference.length);
+		expectShapesToMatch(actual, reference);
+	});
+
+	// Bluefish stacks anchor on the first child whose position is already
+	// owned by another relation (so a StackV [label, Ref(planet)] hangs the
+	// label above the planet without moving it). modular-svg's stack always
+	// repositions every child, dragging the referenced node out of its row.
+	it.fails("StackV over a Ref leaves the referenced node in place", async () => {
+		const reference = await renderBluefish((bf) => [
+			bf.Background(
+				{ padding: 40 },
+				bf.StackH(
+					{ spacing: 50 },
+					planetCircles.map((c, i) =>
+						bf.Circle({ ...c, name: i === 0 ? "mercury" : `p${i}` }),
+					),
+				),
+			),
+			bf.StackV({ spacing: 30 }, [
+				bf.Rect({ width: 20, height: 10 }),
+				bf.Ref({ select: "mercury" }),
+			]),
+		]);
+		const actual = renderModular({
+			type: "Group",
+			id: "root",
+			children: [
+				{
+					type: "Background",
+					id: "bg",
+					props: { padding: 40 },
+					children: [
+						{
+							type: "StackH",
+							id: "planets",
+							props: { spacing: 50 },
+							children: planetCircles.map((c, i) => ({
+								type: "Circle",
+								id: i === 0 ? "mercury" : `p${i}`,
+								props: c,
+							})),
+						},
+					],
+				},
+				{
+					type: "StackV",
+					id: "labelStack",
+					props: { spacing: 30 },
+					children: [
+						{ type: "Rect", id: "label", props: { width: 20, height: 10 } },
+						{ type: "Ref", target: "mercury" },
+					],
+				},
+			],
+		});
+		expectShapesToMatch(actual, reference);
+	});
+});

--- a/packages/bluefish-parity/tsconfig.json
+++ b/packages/bluefish-parity/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"types": ["node", "vitest/globals"],
+		"lib": ["ES2022", "DOM", "DOM.Iterable"]
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules"]
+}

--- a/packages/bluefish-parity/vitest.config.ts
+++ b/packages/bluefish-parity/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		environment: "jsdom",
+		setupFiles: ["./src/bluefish-env.ts"],
+	},
+});

--- a/packages/modular-svg-core/src/fuzz.spec.ts
+++ b/packages/modular-svg-core/src/fuzz.spec.ts
@@ -1,0 +1,635 @@
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+import { layoutToSvg } from "./output.ts";
+import { buildSceneFromJson, validate } from "./parser.ts";
+import type { LayoutResult } from "./solver/index.ts";
+import { solveLayout } from "./solver/index.ts";
+
+// The solver is a damped fixed-point iteration (epsilon 1e-6, damping 0.5),
+// so geometric assertions need a tolerance well above the termination
+// threshold but far below any visible difference.
+const EPS = 1e-3;
+
+function close(a: number, b: number, eps = EPS): boolean {
+	return Math.abs(a - b) <= eps;
+}
+
+function solveJson(json: Record<string, unknown>): {
+	layout: LayoutResult;
+	scene: ReturnType<typeof buildSceneFromJson>;
+} {
+	const scene = buildSceneFromJson(json);
+	return { layout: solveLayout(scene), scene };
+}
+
+// ---------------------------------------------------------------------------
+// Arbitraries: JSON scene fragments, fed through the full public pipeline
+// (validate -> buildSceneFromJson -> solveLayout -> layoutToSvg).
+// ---------------------------------------------------------------------------
+
+const sizeArb = fc.integer({ min: 1, max: 200 });
+const posArb = fc.integer({ min: -100, max: 100 });
+const spacingArb = fc.integer({ min: 0, max: 50 });
+const radiusArb = fc.integer({ min: 1, max: 80 });
+const textArb = fc.string({ minLength: 0, maxLength: 12 });
+
+const rectArb = fc
+	.record({ width: sizeArb, height: sizeArb, x: posArb, y: posArb })
+	.map((props) => ({ type: "Rect", props }));
+
+const circleArb = fc
+	.record({ r: radiusArb })
+	.map((props) => ({ type: "Circle", props }));
+
+const textNodeArb = fc
+	.record({ text: textArb })
+	.map((props) => ({ type: "Text", props }));
+
+const leafArb = fc.oneof(rectArb, circleArb, textNodeArb);
+
+type JsonNode = Record<string, unknown>;
+
+function withIds(leaves: JsonNode[]): JsonNode[] {
+	return leaves.map((leaf, i) => ({ ...leaf, id: `leaf${i}` }));
+}
+
+const stackSceneArb = fc.record({
+	horizontal: fc.boolean(),
+	spacing: spacingArb,
+	alignmentIndex: fc.integer({ min: 0, max: 2 }),
+	leaves: fc.array(leafArb, { minLength: 1, maxLength: 6 }),
+});
+
+const alignSceneArb = fc.record({
+	axis: fc.constantFrom("x", "y"),
+	alignment: fc.integer({ min: 0, max: 2 }),
+	rects: fc.array(
+		fc.record({ width: sizeArb, height: sizeArb, x: posArb, y: posArb }),
+		{ minLength: 2, maxLength: 6 },
+	),
+});
+
+const distributeSceneArb = fc.record({
+	axis: fc.constantFrom("x", "y"),
+	spacing: fc.integer({ min: 1, max: 50 }),
+	rects: fc.array(
+		fc.record({ width: sizeArb, height: sizeArb, x: posArb, y: posArb }),
+		{ minLength: 2, maxLength: 6 },
+	),
+});
+
+// Recursive scene: nested stacks / backgrounds / groups over leaves.
+const { tree: nestedNodeArb } = fc.letrec((tie) => ({
+	tree: fc.oneof(
+		{ depthSize: "small", withCrossShrink: true },
+		{ arbitrary: leafArb, weight: 4 },
+		{
+			arbitrary: fc
+				.record({
+					horizontal: fc.boolean(),
+					spacing: spacingArb,
+					children: fc.array(tie("tree"), { minLength: 1, maxLength: 4 }),
+				})
+				.map(({ horizontal, spacing, children }) => ({
+					type: horizontal ? "StackH" : "StackV",
+					props: { spacing },
+					children,
+				})),
+			weight: 2,
+		},
+		{
+			arbitrary: fc
+				.record({
+					padding: fc.integer({ min: 0, max: 30 }),
+					child: tie("tree"),
+				})
+				.map(({ padding, child }) => ({
+					type: "Background",
+					props: { padding },
+					children: [child],
+				})),
+			weight: 1,
+		},
+		{
+			arbitrary: fc
+				.record({
+					children: fc.array(tie("tree"), { minLength: 1, maxLength: 3 }),
+				})
+				.map(({ children }) => ({ type: "Group", children })),
+			weight: 1,
+		},
+	),
+}));
+
+// Flat leaves plus relational operators over Refs, planet-tutorial style.
+const refOpSceneArb = fc
+	.record({
+		leaves: fc.array(leafArb, { minLength: 2, maxLength: 5 }),
+		ops: fc.array(
+			fc.record({
+				kind: fc.constantFrom("align", "distribute"),
+				axis: fc.constantFrom("x", "y"),
+				alignment: fc.constantFrom("left", "center", "right", "top", "bottom"),
+				spacing: fc.integer({ min: 0, max: 50 }),
+				targets: fc.uniqueArray(fc.integer({ min: 0, max: 4 }), {
+					minLength: 2,
+					maxLength: 4,
+				}),
+			}),
+			{ minLength: 0, maxLength: 3 },
+		),
+	})
+	.map(({ leaves, ops }) => {
+		const idLeaves = withIds(leaves as JsonNode[]);
+		const opNodes = ops
+			.map((op, i) => {
+				const targets = op.targets.filter((t) => t < idLeaves.length);
+				if (targets.length < 2) return undefined;
+				const children = targets.map((t) => ({
+					type: "Ref",
+					target: `leaf${t}`,
+				}));
+				if (op.kind === "align") {
+					return {
+						type: "Align",
+						id: `align${i}`,
+						props: { axis: op.axis, alignment: op.alignment },
+						children,
+					};
+				}
+				return {
+					type: "Distribute",
+					id: `dist${i}`,
+					props: { axis: op.axis, spacing: op.spacing },
+					children,
+				};
+			})
+			.filter((n) => n !== undefined) as JsonNode[];
+		return {
+			type: "Group",
+			id: "root",
+			children: [...idLeaves, ...opNodes],
+		} as JsonNode;
+	});
+
+function leafSize(leaf: { type: string; props: Record<string, unknown> }): {
+	width: number;
+	height: number;
+} {
+	if (leaf.type === "Rect") {
+		return {
+			width: leaf.props.width as number,
+			height: leaf.props.height as number,
+		};
+	}
+	if (leaf.type === "Circle") {
+		const r = leaf.props.r as number;
+		return { width: r * 2, height: r * 2 };
+	}
+	return {
+		width: ((leaf.props.text as string) ?? "").length * 8,
+		height: 16,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Stack semantics
+// ---------------------------------------------------------------------------
+
+describe("stack layout properties", () => {
+	it("children are packed along the axis with exact spacing and no overlap", () => {
+		fc.assert(
+			fc.property(stackSceneArb, ({ horizontal, spacing, leaves }) => {
+				const alignments = horizontal
+					? ["top", "centerY", "bottom"]
+					: ["left", "centerX", "right"];
+				const json = {
+					type: horizontal ? "StackH" : "StackV",
+					id: "stack",
+					props: { spacing, alignment: alignments[0] },
+					children: withIds(leaves as JsonNode[]),
+				};
+				const { layout } = solveJson(json);
+				for (let i = 0; i + 1 < leaves.length; i++) {
+					const a = layout[`leaf${i}`];
+					const b = layout[`leaf${i + 1}`];
+					if (horizontal) {
+						expect(close(b.x, a.x + a.width + spacing)).toBe(true);
+					} else {
+						expect(close(b.y, a.y + a.height + spacing)).toBe(true);
+					}
+				}
+			}),
+		);
+	});
+
+	it("container size is the sum along the axis and the max across it", () => {
+		fc.assert(
+			fc.property(stackSceneArb, ({ horizontal, spacing, leaves }) => {
+				const json = {
+					type: horizontal ? "StackH" : "StackV",
+					id: "stack",
+					props: { spacing },
+					children: withIds(leaves as JsonNode[]),
+				};
+				const { layout } = solveJson(json);
+				const sizes = (
+					leaves as { type: string; props: Record<string, unknown> }[]
+				).map(leafSize);
+				const along = horizontal
+					? sizes.reduce((s, z) => s + z.width, 0)
+					: sizes.reduce((s, z) => s + z.height, 0);
+				const across = horizontal
+					? Math.max(...sizes.map((z) => z.height))
+					: Math.max(...sizes.map((z) => z.width));
+				const total = along + spacing * (leaves.length - 1);
+				const c = layout.stack;
+				if (horizontal) {
+					expect(close(c.width, total)).toBe(true);
+					expect(close(c.height, across)).toBe(true);
+				} else {
+					expect(close(c.height, total)).toBe(true);
+					expect(close(c.width, across)).toBe(true);
+				}
+			}),
+		);
+	});
+
+	it("cross-axis alignment holds for every child", () => {
+		fc.assert(
+			fc.property(
+				stackSceneArb,
+				({ horizontal, spacing, alignmentIndex, leaves }) => {
+					const alignments = horizontal
+						? (["top", "centerY", "bottom"] as const)
+						: (["left", "centerX", "right"] as const);
+					const alignment = alignments[alignmentIndex];
+					const json = {
+						type: horizontal ? "StackH" : "StackV",
+						id: "stack",
+						props: { spacing, alignment },
+						children: withIds(leaves as JsonNode[]),
+					};
+					const { layout } = solveJson(json);
+					const c = layout.stack;
+					for (let i = 0; i < leaves.length; i++) {
+						const b = layout[`leaf${i}`];
+						if (horizontal) {
+							if (alignment === "top") expect(close(b.y, 0)).toBe(true);
+							if (alignment === "centerY")
+								expect(close(b.y + b.height / 2, c.height / 2)).toBe(true);
+							if (alignment === "bottom")
+								expect(close(b.y + b.height, c.height)).toBe(true);
+						} else {
+							if (alignment === "left") expect(close(b.x, 0)).toBe(true);
+							if (alignment === "centerX")
+								expect(close(b.x + b.width / 2, c.width / 2)).toBe(true);
+							if (alignment === "right")
+								expect(close(b.x + b.width, c.width)).toBe(true);
+						}
+					}
+				},
+			),
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Align semantics
+// ---------------------------------------------------------------------------
+
+describe("align properties", () => {
+	it("left/top aligns to the minimum initial coordinate", () => {
+		fc.assert(
+			fc.property(alignSceneArb, ({ axis, rects }) => {
+				const alignment = axis === "x" ? "left" : "top";
+				const json = {
+					type: "Group",
+					id: "root",
+					children: [
+						...rects.map((r, i) => ({ type: "Rect", id: `r${i}`, props: r })),
+						{
+							type: "Align",
+							id: "a",
+							props: { axis, alignment },
+							children: rects.map((_r, i) => ({
+								type: "Ref",
+								target: `r${i}`,
+							})),
+						},
+					],
+				};
+				const { layout } = solveJson(json);
+				const min = Math.min(...rects.map((r) => (axis === "x" ? r.x : r.y)));
+				for (let i = 0; i < rects.length; i++) {
+					const v = axis === "x" ? layout[`r${i}`].x : layout[`r${i}`].y;
+					expect(close(v, min)).toBe(true);
+				}
+			}),
+		);
+	});
+
+	it("right/bottom aligns trailing edges to the maximum initial edge", () => {
+		fc.assert(
+			fc.property(alignSceneArb, ({ axis, rects }) => {
+				const alignment = axis === "x" ? "right" : "bottom";
+				const json = {
+					type: "Group",
+					id: "root",
+					children: [
+						...rects.map((r, i) => ({ type: "Rect", id: `r${i}`, props: r })),
+						{
+							type: "Align",
+							id: "a",
+							props: { axis, alignment },
+							children: rects.map((_r, i) => ({
+								type: "Ref",
+								target: `r${i}`,
+							})),
+						},
+					],
+				};
+				const { layout } = solveJson(json);
+				const maxEdge = Math.max(
+					...rects.map((r) => (axis === "x" ? r.x + r.width : r.y + r.height)),
+				);
+				for (let i = 0; i < rects.length; i++) {
+					const b = layout[`r${i}`];
+					const edge = axis === "x" ? b.x + b.width : b.y + b.height;
+					expect(close(edge, maxEdge)).toBe(true);
+				}
+			}),
+		);
+	});
+
+	// NOTE: the parser is asymmetric here. Align center on the x axis anchors
+	// everything to the LAST child's center (alignXCenterTo); on the y axis it
+	// moves every child to the MEAN of the centers (alignYCenter). Revisit when
+	// aligning semantics with Bluefish.
+	it("center collapses all centers onto a single coordinate", () => {
+		fc.assert(
+			fc.property(alignSceneArb, ({ axis, rects }) => {
+				const json = {
+					type: "Group",
+					id: "root",
+					children: [
+						...rects.map((r, i) => ({ type: "Rect", id: `r${i}`, props: r })),
+						{
+							type: "Align",
+							id: "a",
+							props: { axis, alignment: "center" },
+							children: rects.map((_r, i) => ({
+								type: "Ref",
+								target: `r${i}`,
+							})),
+						},
+					],
+				};
+				const { layout } = solveJson(json);
+				const centers = rects.map((_r, i) => {
+					const b = layout[`r${i}`];
+					return axis === "x" ? b.x + b.width / 2 : b.y + b.height / 2;
+				});
+				const expected =
+					axis === "x"
+						? rects[rects.length - 1].x + rects[rects.length - 1].width / 2
+						: rects.reduce((s, r) => s + r.y + r.height / 2, 0) / rects.length;
+				for (const c of centers) {
+					expect(close(c, expected)).toBe(true);
+				}
+			}),
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Distribute semantics
+// ---------------------------------------------------------------------------
+
+describe("distribute properties", () => {
+	it("positive spacing yields exactly that gap between consecutive boxes", () => {
+		fc.assert(
+			fc.property(distributeSceneArb, ({ axis, spacing, rects }) => {
+				const json = {
+					type: "Group",
+					id: "root",
+					children: [
+						...rects.map((r, i) => ({ type: "Rect", id: `r${i}`, props: r })),
+						{
+							type: "Distribute",
+							id: "d",
+							props: { axis, spacing },
+							children: rects.map((_r, i) => ({
+								type: "Ref",
+								target: `r${i}`,
+							})),
+						},
+					],
+				};
+				const { layout } = solveJson(json);
+				for (let i = 0; i + 1 < rects.length; i++) {
+					const a = layout[`r${i}`];
+					const b = layout[`r${i + 1}`];
+					const gap =
+						axis === "x" ? b.x - (a.x + a.width) : b.y - (a.y + a.height);
+					expect(close(gap, spacing)).toBe(true);
+				}
+			}),
+		);
+	});
+
+	it("the last child is the anchor and never moves", () => {
+		fc.assert(
+			fc.property(distributeSceneArb, ({ axis, spacing, rects }) => {
+				const json = {
+					type: "Group",
+					id: "root",
+					children: [
+						...rects.map((r, i) => ({ type: "Rect", id: `r${i}`, props: r })),
+						{
+							type: "Distribute",
+							id: "d",
+							props: { axis, spacing },
+							children: rects.map((_r, i) => ({
+								type: "Ref",
+								target: `r${i}`,
+							})),
+						},
+					],
+				};
+				const { layout } = solveJson(json);
+				const last = rects[rects.length - 1];
+				const b = layout[`r${rects.length - 1}`];
+				if (axis === "x") expect(close(b.x, last.x)).toBe(true);
+				else expect(close(b.y, last.y)).toBe(true);
+			}),
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Background semantics
+// ---------------------------------------------------------------------------
+
+describe("background properties", () => {
+	it("the box is the child's bounds inflated by padding on all sides", () => {
+		fc.assert(
+			fc.property(
+				fc.record({
+					padding: fc.integer({ min: 0, max: 30 }),
+					leaf: leafArb,
+				}),
+				({ padding, leaf }) => {
+					const json = {
+						type: "Background",
+						id: "bg",
+						props: { padding },
+						children: [{ ...(leaf as JsonNode), id: "child" }],
+					};
+					const { layout } = solveJson(json);
+					const child = layout.child;
+					const box = layout.bg;
+					expect(close(box.x, child.x - padding)).toBe(true);
+					expect(close(box.y, child.y - padding)).toBe(true);
+					expect(close(box.width, child.width + padding * 2)).toBe(true);
+					expect(close(box.height, child.height + padding * 2)).toBe(true);
+				},
+			),
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Whole-pipeline fuzzing: anything the schema accepts must not crash, must
+// converge to finite values, must validate, and must serialize to sane SVG.
+// ---------------------------------------------------------------------------
+
+const anySceneArb = fc.oneof(nestedNodeArb, refOpSceneArb);
+
+describe("pipeline fuzzing", () => {
+	it("generated scenes pass schema validation", async () => {
+		await fc.assert(
+			fc.asyncProperty(anySceneArb, async (json) => {
+				await validate(json);
+			}),
+			{ numRuns: 200 },
+		);
+	});
+
+	it("solving never crashes and every coordinate is finite", () => {
+		fc.assert(
+			fc.property(anySceneArb, (json) => {
+				const { layout } = solveJson(json as JsonNode);
+				for (const box of Object.values(layout)) {
+					expect(Number.isFinite(box.x)).toBe(true);
+					expect(Number.isFinite(box.y)).toBe(true);
+					expect(Number.isFinite(box.width)).toBe(true);
+					expect(Number.isFinite(box.height)).toBe(true);
+				}
+			}),
+			{ numRuns: 300 },
+		);
+	});
+
+	it("solving is deterministic", () => {
+		fc.assert(
+			fc.property(anySceneArb, (json) => {
+				const a = solveLayout(buildSceneFromJson(json as JsonNode));
+				const b = solveLayout(buildSceneFromJson(json as JsonNode));
+				expect(a).toEqual(b);
+			}),
+			{ numRuns: 100 },
+		);
+	});
+
+	it("node ids are unique", () => {
+		fc.assert(
+			fc.property(anySceneArb, (json) => {
+				const scene = buildSceneFromJson(json as JsonNode);
+				const ids = scene.nodes.map((n) => n.id);
+				expect(new Set(ids).size).toBe(ids.length);
+			}),
+			{ numRuns: 200 },
+		);
+	});
+
+	it("serialized SVG has no NaN/Infinity and balanced markup", () => {
+		fc.assert(
+			fc.property(
+				anySceneArb,
+				fc.integer({ min: 0, max: 20 }),
+				(json, margin) => {
+					const scene = buildSceneFromJson(json as JsonNode);
+					const layout = solveLayout(scene);
+					const svg = layoutToSvg(layout, scene.nodes, margin);
+					expect(svg).not.toContain("NaN");
+					expect(svg).not.toContain("Infinity");
+					const opens = svg.match(/<(?!\/)[a-z]+/g) ?? [];
+					const closes = svg.match(/<\/[a-z]+>|\/>/g) ?? [];
+					expect(opens.length).toBe(closes.length);
+				},
+			),
+			{ numRuns: 200 },
+		);
+	});
+
+	it("XML special characters in text content are escaped", () => {
+		fc.assert(
+			fc.property(fc.string({ minLength: 1, maxLength: 20 }), (text) => {
+				const json = {
+					type: "Text",
+					id: "t",
+					props: { text },
+				};
+				const scene = buildSceneFromJson(json);
+				const layout = solveLayout(scene);
+				const svg = layoutToSvg(layout, scene.nodes);
+				const body = svg.replace(/<[^>]*>/g, "");
+				expect(body).not.toMatch(/[<]/);
+				expect(body).not.toMatch(/&(?!amp;|lt;|gt;|quot;|apos;|#)/);
+			}),
+			{ numRuns: 200 },
+		);
+	});
+
+	it("every emitted shape lies inside the SVG viewport", () => {
+		fc.assert(
+			fc.property(
+				anySceneArb,
+				fc.integer({ min: 0, max: 20 }),
+				(json, margin) => {
+					const scene = buildSceneFromJson(json as JsonNode);
+					const layout = solveLayout(scene);
+					const svg = layoutToSvg(layout, scene.nodes, margin);
+					const width = Number(svg.match(/width="([^"]+)"/)?.[1]);
+					const height = Number(svg.match(/height="([^"]+)"/)?.[1]);
+					const rects = [
+						...svg.matchAll(
+							/<rect[^>]*\bx="([^"]+)" y="([^"]+)" width="([^"]+)" height="([^"]+)"/g,
+						),
+					];
+					for (const m of rects) {
+						const [x, y, w, h] = m.slice(1).map(Number);
+						expect(x).toBeGreaterThanOrEqual(-EPS);
+						expect(y).toBeGreaterThanOrEqual(-EPS);
+						expect(x + w).toBeLessThanOrEqual(width + EPS);
+						expect(y + h).toBeLessThanOrEqual(height + EPS);
+					}
+					const circles = [
+						...svg.matchAll(
+							/<circle[^>]*\bcx="([^"]+)" cy="([^"]+)" r="([^"]+)"/g,
+						),
+					];
+					for (const m of circles) {
+						const [cx, cy, r] = m.slice(1).map(Number);
+						expect(cx - r).toBeGreaterThanOrEqual(-EPS);
+						expect(cy - r).toBeGreaterThanOrEqual(-EPS);
+						expect(cx + r).toBeLessThanOrEqual(width + EPS);
+						expect(cy + r).toBeLessThanOrEqual(height + EPS);
+					}
+				},
+			),
+			{ numRuns: 200 },
+		);
+	});
+});

--- a/packages/modular-svg-core/src/output.spec.ts
+++ b/packages/modular-svg-core/src/output.spec.ts
@@ -25,9 +25,11 @@ describe("layoutToSvg", () => {
 		];
 		const layout: LayoutResult = { C: { x: 2, y: 3, width: 10, height: 10 } };
 		const svg = layoutToSvg(layout, nodes);
+		// The layout is translated so its bounds start at the margin (0 here),
+		// so the circle at (2,3) ends up centered at (5,5) in a 10x10 viewport.
 		expect(svg).toContain('<circle id="C"');
-		expect(svg).toContain('cx="7"');
-		expect(svg).toContain('cy="8"');
+		expect(svg).toContain('cx="5"');
+		expect(svg).toContain('cy="5"');
 	});
 
 	it("applies fill and stroke and text", () => {

--- a/packages/modular-svg-core/src/output.ts
+++ b/packages/modular-svg-core/src/output.ts
@@ -4,7 +4,21 @@ import { layoutToAst, type SvgDocument, type SvgElement } from "./svg_ast.ts";
 // Re-export for convenience
 export { layoutBounds } from "./svg_ast.ts";
 
-// XML serialization helper
+// Escape XML text content
+export function escapeXml(value: string): string {
+	return value
+		.replaceAll("&", "&amp;")
+		.replaceAll("<", "&lt;")
+		.replaceAll(">", "&gt;");
+}
+
+// Escape XML attribute values (double-quoted)
+function escapeAttr(value: string): string {
+	return escapeXml(value).replaceAll('"', "&quot;");
+}
+
+// XML serialization helper; children strings must already be escaped or be
+// serialized elements
 export function xml(
 	tag: string,
 	args: Record<string, string | number | undefined>,
@@ -12,7 +26,7 @@ export function xml(
 ): string {
 	const attr = Object.entries(args)
 		.filter(([, v]) => v !== undefined)
-		.map(([k, v]) => ` ${k}="${v}"`)
+		.map(([k, v]) => ` ${k}="${typeof v === "string" ? escapeAttr(v) : v}"`)
 		.join("");
 	if (children === undefined) return `<${tag}${attr} />`;
 	const body = Array.isArray(children) ? children.join("") : children;
@@ -59,7 +73,7 @@ function serializeElement(element: SvgElement): string {
 				stroke: element.stroke,
 				"stroke-width": element.strokeWidth,
 			},
-			element.text,
+			escapeXml(element.text),
 		);
 	}
 

--- a/packages/modular-svg-core/src/parser.ts
+++ b/packages/modular-svg-core/src/parser.ts
@@ -265,7 +265,8 @@ export function buildSceneFromJson(json: Record<string, unknown>): JsonScene {
 					kind: "background",
 					box: rec,
 					child: children[0],
-					padding: (node.props?.padding as number) ?? 0,
+					// Default padding matches Bluefish
+					padding: (node.props?.padding as number) ?? 10,
 				});
 			} else if (node.type === "Arrow" && children.length >= 2) {
 				(rec as NodeRecord).from = children[0].id;
@@ -293,13 +294,14 @@ export function buildSceneFromJson(json: Record<string, unknown>): JsonScene {
 			const containerIdx = indexMap.get(d.container.id);
 			if (containerIdx === undefined)
 				throw new Error(`Unknown id ${d.container.id}`);
+			// Defaults match Bluefish: spacing 10, centered cross-axis alignment
 			if (d.kind === "stackV") {
 				ops.push(
 					stackV(
 						childIndices,
 						containerIdx,
-						(d.props.spacing as number) ?? 0,
-						(d.props.alignment as StackAlignment) ?? "left",
+						(d.props.spacing as number) ?? 10,
+						(d.props.alignment as StackAlignment) ?? "centerX",
 					),
 				);
 			} else {
@@ -307,8 +309,8 @@ export function buildSceneFromJson(json: Record<string, unknown>): JsonScene {
 					stackH(
 						childIndices,
 						containerIdx,
-						(d.props.spacing as number) ?? 0,
-						(d.props.alignment as "top" | "centerY" | "bottom") ?? "top",
+						(d.props.spacing as number) ?? 10,
+						(d.props.alignment as "top" | "centerY" | "bottom") ?? "centerY",
 					),
 				);
 			}

--- a/packages/modular-svg-core/src/solver/operators.ts
+++ b/packages/modular-svg-core/src/solver/operators.ts
@@ -171,7 +171,8 @@ export function distributeY(
 			next[anchor] = y;
 			for (let i = indices.length - 2; i >= 0; i--) {
 				const base = indices[i];
-				const height = cur[base + 3];
+				// indices are y-slots, so the height slot is two after (y, w, h)
+				const height = cur[base + 2];
 				y -= height + spacing;
 				next[base] = y;
 			}

--- a/packages/modular-svg-core/src/svg_ast.ts
+++ b/packages/modular-svg-core/src/svg_ast.ts
@@ -253,10 +253,9 @@ export function layoutToAst(
 	const bounds = layoutBounds(layout, nodes);
 	const min = bounds.start;
 	const max = bounds.end;
-	const offset = vec(
-		(min.x < 0 ? -min.x : 0) + margin,
-		(min.y < 0 ? -min.y : 0) + margin,
-	);
+	// Translate the layout so its bounds start at the margin; otherwise
+	// content with a positive minimum would sit outside the viewport.
+	const offset = vec(-min.x + margin, -min.y + margin);
 
 	const children: SvgElement[] = [];
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,28 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@26.1.1)(jsdom@29.1.1)(vite@8.1.3(@types/node@26.1.1)(tsx@4.20.3))
+        version: 4.1.10(@types/node@26.1.1)(jsdom@29.1.1)(vite@8.1.3(@types/node@26.1.1)(jiti@1.21.7)(tsx@4.20.3))
+
+  packages/bluefish-parity:
+    devDependencies:
+      '@modular-svg/core':
+        specifier: workspace:*
+        version: link:../modular-svg-core
+      '@types/jsdom':
+        specifier: ^27.0.0
+        version: 27.0.0
+      bluefish-js:
+        specifier: 0.0.39
+        version: 0.0.39(tsx@4.20.3)
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@26.1.1)(jsdom@29.1.1)(vite@8.1.3(@types/node@26.1.1)(jiti@1.21.7)(tsx@4.20.3))
 
   packages/modular-svg-core:
     dependencies:
@@ -42,7 +63,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@26.1.1)(jsdom@29.1.1)(vite@8.1.3(@types/node@26.1.1)(tsx@4.20.3))
+        version: 4.1.10(@types/node@26.1.1)(jsdom@29.1.1)(vite@8.1.3(@types/node@26.1.1)(jiti@1.21.7)(tsx@4.20.3))
 
   packages/modular-svg-react:
     dependencies:
@@ -88,7 +109,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@26.1.1)(jsdom@29.1.1)(vite@8.1.3(@types/node@26.1.1)(tsx@4.20.3))
+        version: 4.1.10(@types/node@26.1.1)(jsdom@29.1.1)(vite@8.1.3(@types/node@26.1.1)(jiti@1.21.7)(tsx@4.20.3))
 
   packages/react-example:
     dependencies:
@@ -113,7 +134,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^6.0.3
-        version: 6.0.3(vite@8.1.3(@types/node@26.1.1)(tsx@4.20.3))
+        version: 6.0.3(vite@8.1.3(@types/node@26.1.1)(jiti@1.21.7)(tsx@4.20.3))
       playwright:
         specifier: ^1.61.1
         version: 1.61.1
@@ -122,9 +143,13 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.1.3
-        version: 8.1.3(@types/node@26.1.1)(tsx@4.20.3)
+        version: 8.1.3(@types/node@26.1.1)(jiti@1.21.7)(tsx@4.20.3)
 
 packages:
+
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
 
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
@@ -420,14 +445,36 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
 
   '@oxc-project/types@0.138.0':
     resolution: {integrity: sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==}
@@ -560,11 +607,23 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/jsdom@27.0.0':
+    resolution: {integrity: sha512-NZyFl/PViwKzdEkQg96gtnB8wm+1ljhdDay9ahn4hgb+SfVtPCbm3TlmDUFXTA+MGN3CijicnMhG18SI5H3rFw==}
+
+  '@types/lodash@4.17.24':
+    resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
 
   '@types/node@26.1.1':
     resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
@@ -586,6 +645,9 @@ packages:
 
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
   '@vitejs/plugin-react@6.0.3':
     resolution: {integrity: sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==}
@@ -640,6 +702,16 @@ packages:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
 
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
+  arg@5.0.2:
+    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
@@ -650,13 +722,44 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
+  binary-extensions@2.3.0:
+    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
+    engines: {node: '>=8'}
+
+  bluefish-js@0.0.39:
+    resolution: {integrity: sha512-4c6I5i4DSVNbzcOz45pmy54/BZ/rQgsOKa/o1AJI4w9OypWBJst0qivMdCU+zOvVpwizDXShWKkyFizz4+oi9w==}
+
+  bluefish-solid@0.0.39:
+    resolution: {integrity: sha512-oXa7jWGNnBTcAStdYnlD1U7OuYUpQQ+qZ6gflmpTQiYwZwnhI94j0TOJJ/+nD+QqnXwwgj+05LyjMH76qwRRlw==}
+    peerDependencies:
+      solid-js: ^1.9.3
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  camelcase-css@2.0.1:
+    resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
+    engines: {node: '>= 6'}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
+    engines: {node: '>= 8.10.0'}
+
+  chroma-js@2.6.0:
+    resolution: {integrity: sha512-BLHvCB9s8Z1EV4ethr6xnkl/P2YRFOGqfgvuMG/MyCbZPrTA+NeiByY6XvgF0zP4/2deU2CXnWyMa3zu1LqQ3A==}
+
   commander@15.0.0:
     resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
     engines: {node: '>=22.12.0'}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -665,8 +768,47 @@ packages:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  css-unit-converter@1.1.2:
+    resolution: {integrity: sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA==}
+
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  dagre@0.8.5:
+    resolution: {integrity: sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==}
 
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
@@ -683,12 +825,26 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  didyoumean@1.2.2:
+    resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+
+  dlv@1.1.3:
+    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
 
   es-module-lexer@2.3.0:
     resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
@@ -712,8 +868,15 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
   fast-uri@3.1.3:
     resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -723,6 +886,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -734,12 +901,54 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  graphlib@2.1.8:
+    resolution: {integrity: sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
 
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
+
+  is-binary-path@2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
+    engines: {node: '>= 0.4'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -748,6 +957,10 @@ packages:
     resolution: {integrity: sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==}
     peerDependencies:
       react: ^19.0.0
+
+  jiti@1.21.7:
+    resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
+    hasBin: true
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -834,6 +1047,16 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
   lru-cache@11.5.2:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
@@ -848,27 +1071,76 @@ packages:
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
   nanoid@3.3.15:
     resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
+
   obug@2.1.3:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
     engines: {node: '>=12.20.0'}
 
+  paper@0.12.18:
+    resolution: {integrity: sha512-ZSLIEejQTJZuYHhSSqAf4jXOnii0kPhCJGAnYAANtdS72aNwXJ9cP95tZHgq1tnNpvEwgQhggy+4OarviqTCGw==}
+    engines: {node: '>=8.0.0'}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  perfect-arrows@0.3.7:
+    resolution: {integrity: sha512-wEN2gerTPVWl3yqoFEF8OeGbg3aRe2sxNUi9rnyYrCsL4JcI6K2tBDezRtqVrYG0BNtsWLdYiiTrYm+X//8yLQ==}
+    engines: {node: '>=10'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
 
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
+
+  pify@2.3.0:
+    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
+    engines: {node: '>=0.10.0'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
 
   playwright-core@1.61.1:
     resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
@@ -879,6 +1151,52 @@ packages:
     resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  postcss-import@15.1.0:
+    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+
+  postcss-js@4.1.0:
+    resolution: {integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==}
+    engines: {node: ^12 || ^14 || >= 16}
+    peerDependencies:
+      postcss: ^8.4.21
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  postcss-nested@6.2.0:
+    resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.2.14
+
+  postcss-selector-parser@6.1.4:
+    resolution: {integrity: sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==}
+    engines: {node: '>=4'}
+
+  postcss-value-parser@3.3.1:
+    resolution: {integrity: sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
   postcss@8.5.16:
     resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
@@ -894,6 +1212,9 @@ packages:
 
   pure-rand@8.4.1:
     resolution: {integrity: sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ==}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   react-dom@19.2.7:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
@@ -913,6 +1234,16 @@ packages:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
 
+  read-cache@1.0.0:
+    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
+
+  readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+
+  reduce-css-calc@2.1.8:
+    resolution: {integrity: sha512-8liAVezDmUcH+tdzoEGrhfbGcP7nOV4NkGE3a74+qqvE7nt9i4sKLGBuZNOnpI4WiGksiNPklZxva80061QiPg==}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -920,10 +1251,22 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
   rolldown@1.1.4:
     resolution: {integrity: sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -932,8 +1275,29 @@ packages:
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
+  seroval-plugins@1.5.4:
+    resolution: {integrity: sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+
+  seroval@1.5.4:
+    resolution: {integrity: sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==}
+    engines: {node: '>=10'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  smiles-drawer@2.4.1:
+    resolution: {integrity: sha512-kJeD91Bp8EwLTQouq4az7hn5zUYdIaLQoyFt8XlsqriugPiZOdBFADJMUnfqDYpyu3XK9SFpBgTuDtczpbSUbA==}
+
+  solid-js@1.9.14:
+    resolution: {integrity: sha512-sAEXC0Kk0S1EDg+8ysEWJDbYhA3RRoEjwuySUGlKIemeo0I5YZfOyumNjNs9Sv3y2nmhD+0rW66ag2HsMuQiGQ==}
+
+  solid-toast@0.5.0:
+    resolution: {integrity: sha512-t770JakjyS2P9b8Qa1zMLOD51KYKWXbTAyJePVUoYex5c5FH5S/HtUBUbZAWFcqRCKmAE8KhyIiCvDZA8bOnxQ==}
+    peerDependencies:
+      solid-js: ^1.5.4
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -945,8 +1309,29 @@ packages:
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tailwindcss@3.4.19:
+    resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -970,6 +1355,10 @@ packages:
     resolution: {integrity: sha512-56L0/9HELHSsG1bFCzay8UoLxzRL7kpFf7Wl5q/kSYwiSJGACvro61xnKzPNM+SadxllzdtXsKDSXE7HPeqIAw==}
     hasBin: true
 
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
   tough-cookie@6.0.2:
     resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
     engines: {node: '>=16'}
@@ -977,6 +1366,9 @@ packages:
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -997,6 +1389,9 @@ packages:
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vite@8.1.3:
     resolution: {integrity: sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==}
@@ -1111,6 +1506,8 @@ packages:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
 snapshots:
+
+  '@alloc/quick-lru@5.2.0': {}
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -1301,7 +1698,19 @@ snapshots:
 
   '@exodus/bytes@1.15.1': {}
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
@@ -1309,6 +1718,18 @@ snapshots:
       '@emnapi/runtime': 1.11.1
       '@tybys/wasm-util': 0.10.3
     optional: true
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
 
   '@oxc-project/types@0.138.0': {}
 
@@ -1402,9 +1823,23 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-time@3.0.4': {}
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
+
+  '@types/jsdom@27.0.0':
+    dependencies:
+      '@types/node': 26.1.1
+      '@types/tough-cookie': 4.0.5
+      parse5: 7.3.0
+
+  '@types/lodash@4.17.24': {}
 
   '@types/node@26.1.1':
     dependencies:
@@ -1426,10 +1861,12 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@vitejs/plugin-react@6.0.3(vite@8.1.3(@types/node@26.1.1)(tsx@4.20.3))':
+  '@types/tough-cookie@4.0.5': {}
+
+  '@vitejs/plugin-react@6.0.3(vite@8.1.3(@types/node@26.1.1)(jiti@1.21.7)(tsx@4.20.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.1.3(@types/node@26.1.1)(tsx@4.20.3)
+      vite: 8.1.3(@types/node@26.1.1)(jiti@1.21.7)(tsx@4.20.3)
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -1440,13 +1877,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@8.1.3(@types/node@26.1.1)(tsx@4.20.3))':
+  '@vitest/mocker@4.1.10(vite@8.1.3(@types/node@26.1.1)(jiti@1.21.7)(tsx@4.20.3))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.3(@types/node@26.1.1)(tsx@4.20.3)
+      vite: 8.1.3(@types/node@26.1.1)(jiti@1.21.7)(tsx@4.20.3)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -1483,6 +1920,15 @@ snapshots:
 
   ansi-styles@5.2.0: {}
 
+  any-promise@1.3.0: {}
+
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.2
+
+  arg@5.0.2: {}
+
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
@@ -1493,9 +1939,59 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
+  binary-extensions@2.3.0: {}
+
+  bluefish-js@0.0.39(tsx@4.20.3):
+    dependencies:
+      bluefish-solid: 0.0.39(solid-js@1.9.14)(tsx@4.20.3)
+      solid-js: 1.9.14
+    transitivePeerDependencies:
+      - tsx
+      - yaml
+
+  bluefish-solid@0.0.39(solid-js@1.9.14)(tsx@4.20.3):
+    dependencies:
+      '@types/d3-scale': 4.0.9
+      '@types/lodash': 4.17.24
+      d3-scale: 4.0.2
+      dagre: 0.8.5
+      lodash: 4.18.1
+      paper: 0.12.18
+      perfect-arrows: 0.3.7
+      reduce-css-calc: 2.1.8
+      smiles-drawer: 2.4.1
+      solid-js: 1.9.14
+      solid-toast: 0.5.0(solid-js@1.9.14)
+      tailwindcss: 3.4.19(tsx@4.20.3)
+    transitivePeerDependencies:
+      - tsx
+      - yaml
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  camelcase-css@2.0.1: {}
+
   chai@6.2.2: {}
 
+  chokidar@3.6.0:
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.3
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  chroma-js@2.6.0: {}
+
   commander@15.0.0: {}
+
+  commander@4.1.1: {}
 
   convert-source-map@2.0.0: {}
 
@@ -1504,7 +2000,44 @@ snapshots:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
 
+  css-unit-converter@1.1.2: {}
+
+  cssesc@3.0.0: {}
+
   csstype@3.2.3: {}
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  dagre@0.8.5:
+    dependencies:
+      graphlib: 2.1.8
+      lodash: 4.18.1
 
   data-urls@7.0.0:
     dependencies:
@@ -1519,9 +2052,17 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
+  didyoumean@1.2.2: {}
+
+  dlv@1.1.3: {}
+
   dom-accessibility-api@0.5.16: {}
 
+  entities@6.0.1: {}
+
   entities@8.0.0: {}
+
+  es-errors@1.3.0: {}
 
   es-module-lexer@2.3.0: {}
 
@@ -1567,11 +2108,27 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
   fast-uri@3.1.3: {}
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
 
   fsevents@2.3.2:
     optional: true
@@ -1579,16 +2136,52 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
     optional: true
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  graphlib@2.1.8:
+    dependencies:
+      lodash: 4.18.1
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
 
   html-encoding-sniffer@6.0.0:
     dependencies:
       '@exodus/bytes': 1.15.1
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  internmap@2.0.3: {}
+
+  is-binary-path@2.1.0:
+    dependencies:
+      binary-extensions: 2.3.0
+
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.4
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-number@7.0.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -1598,6 +2191,8 @@ snapshots:
       react: 19.2.7
     transitivePeerDependencies:
       - '@types/react'
+
+  jiti@1.21.7: {}
 
   js-tokens@4.0.0: {}
 
@@ -1678,6 +2273,12 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  lodash@4.18.1: {}
+
   lru-cache@11.5.2: {}
 
   lz-string@1.5.0: {}
@@ -1688,19 +2289,54 @@ snapshots:
 
   mdn-data@2.27.1: {}
 
+  merge2@1.4.1: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
   nanoid@3.3.15: {}
 
+  normalize-path@3.0.0: {}
+
+  object-assign@4.1.1: {}
+
+  object-hash@3.0.0: {}
+
   obug@2.1.3: {}
+
+  paper@0.12.18: {}
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
 
+  path-parse@1.0.7: {}
+
   pathe@2.0.3: {}
+
+  perfect-arrows@0.3.7: {}
 
   picocolors@1.1.1: {}
 
+  picomatch@2.3.2: {}
+
   picomatch@4.0.5: {}
+
+  pify@2.3.0: {}
+
+  pirates@4.0.7: {}
 
   playwright-core@1.61.1: {}
 
@@ -1709,6 +2345,40 @@ snapshots:
       playwright-core: 1.61.1
     optionalDependencies:
       fsevents: 2.3.2
+
+  postcss-import@15.1.0(postcss@8.5.16):
+    dependencies:
+      postcss: 8.5.16
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.12
+
+  postcss-js@4.1.0(postcss@8.5.16):
+    dependencies:
+      camelcase-css: 2.0.1
+      postcss: 8.5.16
+
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.16)(tsx@4.20.3):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 1.21.7
+      postcss: 8.5.16
+      tsx: 4.20.3
+
+  postcss-nested@6.2.0(postcss@8.5.16):
+    dependencies:
+      postcss: 8.5.16
+      postcss-selector-parser: 6.1.4
+
+  postcss-selector-parser@6.1.4:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
+  postcss-value-parser@3.3.1: {}
+
+  postcss-value-parser@4.2.0: {}
 
   postcss@8.5.16:
     dependencies:
@@ -1726,6 +2396,8 @@ snapshots:
 
   pure-rand@8.4.1: {}
 
+  queue-microtask@1.2.3: {}
+
   react-dom@19.2.7(react@19.2.7):
     dependencies:
       react: 19.2.7
@@ -1740,10 +2412,32 @@ snapshots:
 
   react@19.2.7: {}
 
+  read-cache@1.0.0:
+    dependencies:
+      pify: 2.3.0
+
+  readdirp@3.6.0:
+    dependencies:
+      picomatch: 2.3.2
+
+  reduce-css-calc@2.1.8:
+    dependencies:
+      css-unit-converter: 1.1.2
+      postcss-value-parser: 3.3.1
+
   require-from-string@2.0.2: {}
 
   resolve-pkg-maps@1.0.0:
     optional: true
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
+  reusify@1.1.0: {}
 
   rolldown@1.1.4:
     dependencies:
@@ -1766,13 +2460,37 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.1.4
       '@rolldown/binding-win32-x64-msvc': 1.1.4
 
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
+  seroval-plugins@1.5.4(seroval@1.5.4):
+    dependencies:
+      seroval: 1.5.4
+
+  seroval@1.5.4: {}
+
   siginfo@2.0.0: {}
+
+  smiles-drawer@2.4.1:
+    dependencies:
+      chroma-js: 2.6.0
+
+  solid-js@1.9.14:
+    dependencies:
+      csstype: 3.2.3
+      seroval: 1.5.4
+      seroval-plugins: 1.5.4(seroval@1.5.4)
+
+  solid-toast@0.5.0(solid-js@1.9.14):
+    dependencies:
+      solid-js: 1.9.14
 
   source-map-js@1.2.1: {}
 
@@ -1780,7 +2498,55 @@ snapshots:
 
   std-env@4.2.0: {}
 
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.17
+      ts-interface-checker: 0.1.13
+
+  supports-preserve-symlinks-flag@1.0.0: {}
+
   symbol-tree@3.2.4: {}
+
+  tailwindcss@3.4.19(tsx@4.20.3):
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      arg: 5.0.2
+      chokidar: 3.6.0
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.3.3
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      jiti: 1.21.7
+      lilconfig: 3.1.3
+      micromatch: 4.0.8
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.1.1
+      postcss: 8.5.16
+      postcss-import: 15.1.0(postcss@8.5.16)
+      postcss-js: 4.1.0(postcss@8.5.16)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.16)(tsx@4.20.3)
+      postcss-nested: 6.2.0(postcss@8.5.16)
+      postcss-selector-parser: 6.1.4
+      resolve: 1.22.12
+      sucrase: 3.35.1
+    transitivePeerDependencies:
+      - tsx
+      - yaml
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
 
   tinybench@2.9.0: {}
 
@@ -1799,6 +2565,10 @@ snapshots:
     dependencies:
       tldts-core: 7.4.7
 
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
   tough-cookie@6.0.2:
     dependencies:
       tldts: 7.4.7
@@ -1806,6 +2576,8 @@ snapshots:
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
+
+  ts-interface-checker@0.1.13: {}
 
   tslib@2.8.1:
     optional: true
@@ -1824,7 +2596,9 @@ snapshots:
 
   undici@7.28.0: {}
 
-  vite@8.1.3(@types/node@26.1.1)(tsx@4.20.3):
+  util-deprecate@1.0.2: {}
+
+  vite@8.1.3(@types/node@26.1.1)(jiti@1.21.7)(tsx@4.20.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
@@ -1834,12 +2608,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.1.1
       fsevents: 2.3.3
+      jiti: 1.21.7
       tsx: 4.20.3
 
-  vitest@4.1.10(@types/node@26.1.1)(jsdom@29.1.1)(vite@8.1.3(@types/node@26.1.1)(tsx@4.20.3)):
+  vitest@4.1.10(@types/node@26.1.1)(jsdom@29.1.1)(vite@8.1.3(@types/node@26.1.1)(jiti@1.21.7)(tsx@4.20.3)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@26.1.1)(tsx@4.20.3))
+      '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@26.1.1)(jiti@1.21.7)(tsx@4.20.3))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -1856,7 +2631,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.1.3(@types/node@26.1.1)(tsx@4.20.3)
+      vite: 8.1.3(@types/node@26.1.1)(jiti@1.21.7)(tsx@4.20.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.1.1


### PR DESCRIPTION
Two new test layers for the core, per the plan to test it like a fuzzer and compare against upstream Bluefish.

## Property-based fuzzing (`fuzz.spec.ts`)
Generates whole scene trees (stacks, align, distribute, background, nested containers, ref-based operator combos) and drives the full public pipeline: validate → buildSceneFromJson → solveLayout → layoutToSvg. Invariants: exact stack spacing/packing, container sizing, alignment equalities, distribute gaps + anchoring, background inflation, schema validity, determinism, unique ids, finite coordinates, escaped/balanced markup, viewport containment.

**Bugs it found, fixed here:**
- `distributeY` spacing mode read the *next node's x coordinate* instead of the height (off-by-one on the flat slot array)
- `xml()` didn't escape text/attributes — `<` or `&` in a Text node produced malformed SVG
- layouts with a positive minimum weren't translated into the viewport

## Bluefish parity (`packages/bluefish-parity`)
Renders **real bluefish-js 0.0.39 headlessly** (vitest + jsdom; patches for paper.js UA sniffing, canvas measureText, getComputedTextLength) and compares extracted SVG geometry against our layout, normalized to the union bbox, tolerance 0.01.

**Matching Bluefish exactly:** stack spacing + all six alignments, default spacing/alignment, Background padding (default + explicit), Distribute with spacing, and the planets tutorial pattern (background + stack + align + distribute over refs).

**Defaults changed for parity:** stack spacing 0→10, StackH alignment top→centerY, StackV left→centerX, Background padding 0→10.

**Known divergences** are `it.fails` fixtures that flip when fixed: nested stacks don't compose, and StackV over a Ref moves the referenced node (we have no ownership concept). Text metrics, arrows, and spacing-less Distribute are documented exclusions.

All 104 tests pass (54 core + 14 parity + 29 react + 5 root + 2 CLI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)