### PR TITLE
Add Bluefish parity matrix

### DIFF
--- a/packages/bluefish-parity/PARITY.md
+++ b/packages/bluefish-parity/PARITY.md
@@ -1,0 +1,82 @@
+# Bluefish parity matrix
+
+Feature-by-feature comparison of modular-svg against Bluefish
+(github.com/bluefishjs/bluefish, `main` @ `a6d2134` = npm `0.0.39`,
+verified identical — no unreleased commits as of July 2026).
+
+Status legend:
+
+- ✅ **parity** — matches Bluefish geometry, covered by fixtures in `parity.spec.ts`
+- 🟡 **partial** — core semantics match, listed props/behaviors missing
+- ❌ **missing** — not implemented
+- ➖ **non-goal** — deliberately not matched (reason given)
+- 🚫 **unexported upstream** — exists in Bluefish source but is NOT exported
+  from `bluefish-solid`/`bluefish-js`; matching by omission
+
+## Marks
+
+| Feature | Bluefish (source of truth) | modular-svg | Status |
+|---|---|---|---|
+| **Rect** | `x? y? width? height?` + all SVG attrs pass through (incl. `rx`/`ry`); unset dims stay unowned so relations can size it | `x y width height fill stroke stroke-width(3)`; no arbitrary attr passthrough; unset dims default 0 | 🟡 |
+| **Circle** | `cx? cy?` (center), `r` required; paint derives r from `bbox.width/2`, so parents can resize | `x y` (top-left), `r`; r fixed at parse; `stroke-width` default 1 vs Bluefish none | 🟡 |
+| **Ellipse** | in src, **not exported** from either package (doc stub exists) | — | 🚫 |
+| **Text** | Alegreya Sans 700 14px, canvas-measured; word wrap via `width`, `scaleToFit`, `angle`, `vertical-anchor`, `dx/dy`, line-height/cap-height | heuristic 8px/char × 16px line, single line, `fill` default black | ➖ text metrics (see below) / 🟡 props |
+| **Image** | `x? y? width? height?` + `href`; layout identical to Rect | — | ❌ |
+| **Path** | `d` required, `x? y?`, `position: relative\|absolute`; bounds measured via paper.js; defaults stroke black, sw 3, fill none | — | ❌ |
+| **Blob** | takes a **paper.js `Path` instance** as a prop (not serializable); exported but experimental | — | ➖ not expressible in JSON scenes |
+
+## Relations
+
+| Feature | Bluefish | modular-svg | Status |
+|---|---|---|---|
+| **StackH / StackV** | spacing default 10; alignment centerY/centerX; anchored on first owned child; bbox = union | same (fixtures: spacing, all 6 alignments, defaults, nesting, ref anchoring) | ✅ |
+| Stack `total` modes | `total` only → spacing computed; `total`+`spacing` → children with unowned extent share leftover **size**; `spacing` with unowned extents → `DimUnownedError` | only `spacing`; no extent ownership concept | ❌ |
+| **Stack (generic)** | in src, **not exported**; StackH/V wrap it | — | 🚫 |
+| **Align** | 1D + 2D keywords; first-owned child anchors; bbox exposes only aligned axis | same keywords + anchor (fixtures); container bbox is full union of both axes | ✅ / 🟡 bbox axes |
+| `guidePrimary` per-child override | commented out upstream — not implemented | — | 🚫 |
+| **Distribute** | `direction` required; `spacing`, `total`, or both; first-owned child anchors; bbox exposes main axis only | `axis`/`direction` + `spacing` (fixture); `total` missing; spacing-less → even-spread **extension** (Bluefish throws) | 🟡 |
+| **Background** | padding 10; stroke black / fill none / sw 3; extra rect attrs pass through (`rx` in tutorial!); custom `background` render prop; `width`/`height`; centers unowned content; errors if frame pos owned | padding 10 + fill/stroke/sw (fixtures: default + explicit padding); no `rx`/attr passthrough, no custom frame, no content centering | 🟡 |
+| **Group** | defaults unowned left/top to 0 (claims them); union skipping undefined; `rels` prop; extra attrs on `<g>` | union bbox; relations are just sibling children in JSON (≈ `rels`) | ✅ core / 🟡 details |
+| **Line** | connects 2 children (Refs); `source`/`target` fractional [0..1,0..1] bbox anchors, clamped-to-box endpoint defaults; stroke black sw 3, dasharray | — | ❌ |
+| **Arrow** | perfect-arrows curved quad path: bow .2, stretch .5, stretchMin 40, stretchMax 420, padStart 5, padEnd 20, flip, straights, `start` dot; bbox = union of endpoints' boxes | straight line + polygon head, fixed 5px margins, vertical-biased anchor points; bbox = union (via unionOp) | 🟡 geometry |
+| **GraphLayered / Node / Edge** | dagre layered graph layout; **not exported** | — | 🚫 |
+| **Gradient** | linearGradient defs helper; **not exported** | — | 🚫 |
+
+## Special / framework
+
+| Feature | Bluefish | modular-svg | Status |
+|---|---|---|---|
+| **Bluefish root** | padding 10; optional width/height override; viewBox from content bbox; `debug` scenegraph dump | Group root + `layoutToSvg(margin)` (default 0; CLI default 3); width/height always derived | 🟡 |
+| **Ref** | `select: Id \| [Id, ...names]` — path selection through scoped names; helpful "Available names" errors; ref-of-ref throws | flat `target` id (global unique ids); unknown ref throws | ✅ core / ➖ scoped paths (our ids are globally unique, scoping is moot in JSON) |
+| **name / createName scoping** | scope tree, `name(uid)` ids, `data-bluefish-id` attr on `<g>` | `id`/`key` on nodes → `id` attr on emitted elements | ➖ equivalent-by-design |
+| **zOrder** (new in 0.0.39) | `zOrder?: number` on every component; paint order sorted stably | paint order = node order | ❌ |
+| **withBluefish HOC** | wraps custom components; naming + zOrder | react package reconciler plays this role | ➖ framework-specific |
+| **Layout / LayoutFunction** | custom layout escape hatches (function props) | custom `LayoutOperator` via `solveLayout` API | ➖ equivalent-by-design (not JSON-expressible upstream either) |
+| **Ownership errors** | typed errors (DimAlreadyOwned w/ provenance, DimUnowned, NaN, …) — but currently soft (`console.warn`) | `JsonScene.warnings` for double hard ownership; hard throws for dup ids / unknown refs | ✅ comparable |
+| **Reactivity / control flow** | Solid signals; For/Show/Index/Switch/Match (hyperscript) | react package (state → re-render); JSON is data | ➖ framework-specific |
+| **Interactivity** | signals driving props; no dedicated API | react Canvas event handlers | ➖ different mechanism |
+| **debug / window.bluefish / DEBUG-name breakpoints** | scenegraph dump, debugger triggers | — | ➖ |
+
+## Layout-model differences (accepted)
+
+- Bluefish: linear-system bbox (any 2 dims per axis determine all 4; over-determination throws),
+  single bottom-up pass, per-container transforms.
+  modular-svg: flat `Float64Array`, damped fixed-point solver, parse-time ownership,
+  subtree-delta moves. Geometry parity is verified by fixture, not by construction.
+- Distribute/Align in Bluefish expose partial bboxes (one axis); our containers always
+  get full union bboxes. Only observable when another relation targets those containers.
+
+## Suggested closing order
+
+1. **zOrder** — trivial (sort in `layoutToAst`), new upstream feature.
+2. **Image** — Rect-clone with `href` passthrough.
+3. **Rect/Background SVG attr passthrough** (`rx` is used in the official tutorial).
+4. **Stack/Distribute `total` modes** — needs extent ownership (we already track
+   whether `width`/`height` props were given, same mechanism as position ownership).
+5. **Line** — fractional-anchor endpoints between two refs.
+6. **Arrow geometry** — port/adopt perfect-arrows' `getBoxToBoxArrow` for curve parity.
+7. **Circle `cx`/`cy`** — accept center coords alongside top-left.
+
+Non-goals (revisit only deliberately): text metrics (needs real font measurement),
+Path/Blob (paper.js), anything unexported upstream (Ellipse, generic Stack, Gradient,
+GraphLayered), scoped name paths, debug tooling.


### PR DESCRIPTION
Documents the full feature surface of Bluefish main (verified = npm 0.0.39, no unreleased commits) against our implementation, in `packages/bluefish-parity/PARITY.md`. Drives the next round of parity fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)