### PR TITLE
Close the seven Bluefish parity gaps

### DIFF
--- a/packages/bluefish-parity/PARITY.md
+++ b/packages/bluefish-parity/PARITY.md
@@ -17,11 +17,11 @@ Status legend:
 
 | Feature | Bluefish (source of truth) | modular-svg | Status |
 |---|---|---|---|
-| **Rect** | `x? y? width? height?` + all SVG attrs pass through (incl. `rx`/`ry`); unset dims stay unowned so relations can size it | `x y width height fill stroke stroke-width(3)`; no arbitrary attr passthrough; unset dims default 0 | 🟡 |
-| **Circle** | `cx? cy?` (center), `r` required; paint derives r from `bbox.width/2`, so parents can resize | `x y` (top-left), `r`; r fixed at parse; `stroke-width` default 1 vs Bluefish none | 🟡 |
+| **Rect** | `x? y? width? height?` + all SVG attrs pass through (incl. `rx`/`ry`); unset dims stay unowned so relations can size it | same + arbitrary SVG attr passthrough; unset extents are unowned (assignable by total modes) | ✅ |
+| **Circle** | `cx? cy?` (center), `r` required; paint derives r from `bbox.width/2`, so parents can resize | `cx cy` and top-left `x y` both accepted (fixture); r fixed at parse; no stroke-width default (matches Bluefish) | ✅ / 🟡 parent-resize |
 | **Ellipse** | in src, **not exported** from either package (doc stub exists) | — | 🚫 |
 | **Text** | Alegreya Sans 700 14px, canvas-measured; word wrap via `width`, `scaleToFit`, `angle`, `vertical-anchor`, `dx/dy`, line-height/cap-height | heuristic 8px/char × 16px line, single line, `fill` default black | ➖ text metrics (see below) / 🟡 props |
-| **Image** | `x? y? width? height?` + `href`; layout identical to Rect | — | ❌ |
+| **Image** | `x? y? width? height?` + `href`; layout identical to Rect | same (fixture: image in a stack) | ✅ |
 | **Path** | `d` required, `x? y?`, `position: relative\|absolute`; bounds measured via paper.js; defaults stroke black, sw 3, fill none | — | ❌ |
 | **Blob** | takes a **paper.js `Path` instance** as a prop (not serializable); exported but experimental | — | ➖ not expressible in JSON scenes |
 
@@ -30,15 +30,15 @@ Status legend:
 | Feature | Bluefish | modular-svg | Status |
 |---|---|---|---|
 | **StackH / StackV** | spacing default 10; alignment centerY/centerX; anchored on first owned child; bbox = union | same (fixtures: spacing, all 6 alignments, defaults, nesting, ref anchoring) | ✅ |
-| Stack `total` modes | `total` only → spacing computed; `total`+`spacing` → children with unowned extent share leftover **size**; `spacing` with unowned extents → `DimUnownedError` | only `spacing`; no extent ownership concept | ❌ |
+| Stack `total` modes | `total` only → spacing computed; `total`+`spacing` → children with unowned extent share leftover **size** (Bluefish quirk: gaps not subtracted — preserved); `spacing` with unowned extents → `DimUnownedError` | same three modes via extent ownership (fixtures); unowned-extent violations land in `warnings` | ✅ |
 | **Stack (generic)** | in src, **not exported**; StackH/V wrap it | — | 🚫 |
 | **Align** | 1D + 2D keywords; first-owned child anchors; bbox exposes only aligned axis | same keywords + anchor (fixtures); container bbox is full union of both axes | ✅ / 🟡 bbox axes |
 | `guidePrimary` per-child override | commented out upstream — not implemented | — | 🚫 |
-| **Distribute** | `direction` required; `spacing`, `total`, or both; first-owned child anchors; bbox exposes main axis only | `axis`/`direction` + `spacing` (fixture); `total` missing; spacing-less → even-spread **extension** (Bluefish throws) | 🟡 |
-| **Background** | padding 10; stroke black / fill none / sw 3; extra rect attrs pass through (`rx` in tutorial!); custom `background` render prop; `width`/`height`; centers unowned content; errors if frame pos owned | padding 10 + fill/stroke/sw (fixtures: default + explicit padding); no `rx`/attr passthrough, no custom frame, no content centering | 🟡 |
+| **Distribute** | `direction` required; `spacing`, `total`, or both; first-owned child anchors; bbox exposes main axis only | `direction` horizontal/vertical or `axis` x/y; all three sizing modes (fixtures); spacing-less → even-spread **extension** (Bluefish throws) | ✅ |
+| **Background** | padding 10; stroke black / fill none / sw 3; extra rect attrs pass through (`rx` in tutorial!); custom `background` render prop; `width`/`height`; centers unowned content; errors if frame pos owned | padding 10 + fill/stroke/sw + attr passthrough incl. `rx` (fixtures); no custom frame, no content centering | ✅ core / 🟡 details |
 | **Group** | defaults unowned left/top to 0 (claims them); union skipping undefined; `rels` prop; extra attrs on `<g>` | union bbox; relations are just sibling children in JSON (≈ `rels`) | ✅ core / 🟡 details |
-| **Line** | connects 2 children (Refs); `source`/`target` fractional [0..1,0..1] bbox anchors, clamped-to-box endpoint defaults; stroke black sw 3, dasharray | — | ❌ |
-| **Arrow** | perfect-arrows curved quad path: bow .2, stretch .5, stretchMin 40, stretchMax 420, padStart 5, padEnd 20, flip, straights, `start` dot; bbox = union of endpoints' boxes | straight line + polygon head, fixed 5px margins, vertical-biased anchor points; bbox = union (via unionOp) | 🟡 geometry |
+| **Line** | connects 2 children (Refs); `source`/`target` fractional [0..1,0..1] bbox anchors, clamped-to-box endpoint defaults; stroke black sw 3, dasharray | same, ported endpoint algorithm incl. center-bias quirk (fixtures: both anchors / source only / none); dasharray via attr passthrough | ✅ |
+| **Arrow** | perfect-arrows curved quad path: bow .2, stretch .5, stretchMin 40, stretchMax 420, padStart 5, padEnd 20, flip, straights, `start` dot; bbox = union of endpoints' boxes | same: perfect-arrows dependency, identical defaults, path + rotated polygon head + optional start dot (fixture compares path coords exactly) | ✅ |
 | **GraphLayered / Node / Edge** | dagre layered graph layout; **not exported** | — | 🚫 |
 | **Gradient** | linearGradient defs helper; **not exported** | — | 🚫 |
 
@@ -49,7 +49,7 @@ Status legend:
 | **Bluefish root** | padding 10; optional width/height override; viewBox from content bbox; `debug` scenegraph dump | Group root + `layoutToSvg(margin)` (default 0; CLI default 3); width/height always derived | 🟡 |
 | **Ref** | `select: Id \| [Id, ...names]` — path selection through scoped names; helpful "Available names" errors; ref-of-ref throws | flat `target` id (global unique ids); unknown ref throws | ✅ core / ➖ scoped paths (our ids are globally unique, scoping is moot in JSON) |
 | **name / createName scoping** | scope tree, `name(uid)` ids, `data-bluefish-id` attr on `<g>` | `id`/`key` on nodes → `id` attr on emitted elements | ➖ equivalent-by-design |
-| **zOrder** (new in 0.0.39) | `zOrder?: number` on every component; paint order sorted stably | paint order = node order | ❌ |
+| **zOrder** (new in 0.0.39) | `zOrder?: number` on every component; paint order sorted stably per parent | `zOrder` prop, global stable sort in layoutToAst (fixture); nuance: Bluefish sorts per parent, we sort globally | ✅ / 🟡 nuance |
 | **withBluefish HOC** | wraps custom components; naming + zOrder | react package reconciler plays this role | ➖ framework-specific |
 | **Layout / LayoutFunction** | custom layout escape hatches (function props) | custom `LayoutOperator` via `solveLayout` API | ➖ equivalent-by-design (not JSON-expressible upstream either) |
 | **Ownership errors** | typed errors (DimAlreadyOwned w/ provenance, DimUnowned, NaN, …) — but currently soft (`console.warn`) | `JsonScene.warnings` for double hard ownership; hard throws for dup ids / unknown refs | ✅ comparable |
@@ -66,16 +66,11 @@ Status legend:
 - Distribute/Align in Bluefish expose partial bboxes (one axis); our containers always
   get full union bboxes. Only observable when another relation targets those containers.
 
-## Suggested closing order
+## Remaining gaps (deliberate or low priority)
 
-1. **zOrder** — trivial (sort in `layoutToAst`), new upstream feature.
-2. **Image** — Rect-clone with `href` passthrough.
-3. **Rect/Background SVG attr passthrough** (`rx` is used in the official tutorial).
-4. **Stack/Distribute `total` modes** — needs extent ownership (we already track
-   whether `width`/`height` props were given, same mechanism as position ownership).
-5. **Line** — fractional-anchor endpoints between two refs.
-6. **Arrow geometry** — port/adopt perfect-arrows' `getBoxToBoxArrow` for curve parity.
-7. **Circle `cx`/`cy`** — accept center coords alongside top-left.
+- Text props/metrics; Path mark; Blob; parent-resizable circles; Background
+  custom frame + content centering; Bluefish-root width/height overrides;
+  per-parent zOrder scoping; partial-axis container bboxes.
 
 Non-goals (revisit only deliberately): text metrics (needs real font measurement),
 Path/Blob (paper.js), anything unexported upstream (Ellipse, generic Stack, Gradient,

--- a/packages/bluefish-parity/src/harness.ts
+++ b/packages/bluefish-parity/src/harness.ts
@@ -1,9 +1,14 @@
-import { buildSceneFromJson, solveLayout } from "@modular-svg/core";
+import {
+	buildSceneFromJson,
+	layoutToSvg,
+	solveLayout,
+} from "@modular-svg/core";
 
 // A normalized shape: x/y is always the top-left of the bounding box so
-// circles and rects compare uniformly across both systems.
+// circles and rects compare uniformly across both systems. Lines keep their
+// direction: x/y is the start point and width/height the signed delta.
 export type Shape = {
-	kind: "circle" | "rect";
+	kind: "circle" | "rect" | "image" | "line";
 	x: number;
 	y: number;
 	width: number;
@@ -52,14 +57,20 @@ function collectShapes(el: Element, tx: number, ty: number, out: Shape[]) {
 			width: r * 2,
 			height: r * 2,
 		});
-	} else if (tag === "rect") {
+	} else if (tag === "rect" || tag === "image") {
 		out.push({
-			kind: "rect",
+			kind: tag as "rect" | "image",
 			x: Number.parseFloat(el.getAttribute("x") ?? "0") + ax,
 			y: Number.parseFloat(el.getAttribute("y") ?? "0") + ay,
 			width: Number.parseFloat(el.getAttribute("width") ?? "0"),
 			height: Number.parseFloat(el.getAttribute("height") ?? "0"),
 		});
+	} else if (tag === "line") {
+		const x1 = Number.parseFloat(el.getAttribute("x1") ?? "0") + ax;
+		const y1 = Number.parseFloat(el.getAttribute("y1") ?? "0") + ay;
+		const x2 = Number.parseFloat(el.getAttribute("x2") ?? "0") + ax;
+		const y2 = Number.parseFloat(el.getAttribute("y2") ?? "0") + ay;
+		out.push({ kind: "line", x: x1, y: y1, width: x2 - x1, height: y2 - y1 });
 	}
 	for (const child of Array.from(el.children)) {
 		collectShapes(child, ax, ay, out);
@@ -100,7 +111,8 @@ export function renderModular(json: Record<string, unknown>): Shape[] {
 	const layout = solveLayout(scene);
 	const shapes: Shape[] = [];
 	for (const n of scene.nodes) {
-		if (n.type !== "rect" && n.type !== "circle") continue;
+		if (n.type !== "rect" && n.type !== "circle" && n.type !== "image")
+			continue;
 		const box = layout[n.id];
 		shapes.push({
 			kind: n.type,
@@ -111,6 +123,43 @@ export function renderModular(json: Record<string, unknown>): Shape[] {
 		});
 	}
 	return shapes;
+}
+
+// Render a JSON scene all the way to SVG and extract shapes from the markup,
+// exactly like the Bluefish side. Needed for output-time geometry (lines,
+// arrows) and paint order. Note: emitted rects are inflated by half their
+// stroke width, so stroke-sensitive fixtures should use "stroke-width": 0.
+export function renderModularSvg(
+	json: Record<string, unknown>,
+	margin = 0,
+): { shapes: Shape[]; svg: string } {
+	const scene = buildSceneFromJson(json);
+	const layout = solveLayout(scene);
+	const svg = layoutToSvg(layout, scene.nodes, margin);
+	const doc = new DOMParser().parseFromString(svg, "image/svg+xml");
+	const shapes: Shape[] = [];
+	collectShapes(doc.documentElement, 0, 0, shapes);
+	return { shapes, svg };
+}
+
+// Render a Bluefish diagram and return the raw SVG markup alongside shapes.
+export async function renderBluefishSvg(
+	diagram: (bf: BluefishModule) => unknown,
+): Promise<{ shapes: Shape[]; svg: string }> {
+	const bf = await bluefish();
+	const app = document.createElement("div");
+	document.body.appendChild(app);
+	const dispose = bf.render(() => diagram(bf) as never, app);
+	try {
+		const svgEl = app.querySelector("svg");
+		if (!svgEl) throw new Error("bluefish did not render an <svg>");
+		const shapes: Shape[] = [];
+		collectShapes(svgEl, 0, 0, shapes);
+		return { shapes, svg: svgEl.outerHTML };
+	} finally {
+		dispose();
+		app.remove();
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -134,13 +183,31 @@ export function normalize(shapes: Shape[]): Shape[] {
 		);
 }
 
+// Translate shapes to the union origin without sorting (paint order matters)
+function shiftToOrigin(shapes: Shape[]): Shape[] {
+	const minX = Math.min(...shapes.map((s) => s.x));
+	const minY = Math.min(...shapes.map((s) => s.y));
+	return shapes.map((s) => ({ ...s, x: s.x - minX, y: s.y - minY }));
+}
+
+// Order-preserving comparison for paint-order (zOrder) fixtures
+export function expectPaintOrderToMatch(
+	actual: Shape[],
+	reference: Shape[],
+	tolerance = 0.01,
+): void {
+	comparePairwise(shiftToOrigin(actual), shiftToOrigin(reference), tolerance);
+}
+
 export function expectShapesToMatch(
 	actual: Shape[],
 	reference: Shape[],
 	tolerance = 0.01,
 ): void {
-	const a = normalize(actual);
-	const b = normalize(reference);
+	comparePairwise(normalize(actual), normalize(reference), tolerance);
+}
+
+function comparePairwise(a: Shape[], b: Shape[], tolerance: number): void {
 	if (a.length !== b.length) {
 		throw new Error(
 			`shape count mismatch: modular-svg=${a.length} bluefish=${b.length}\n` +

--- a/packages/bluefish-parity/src/parity-gaps.spec.ts
+++ b/packages/bluefish-parity/src/parity-gaps.spec.ts
@@ -1,0 +1,314 @@
+import { describe, expect, it } from "vitest";
+import {
+	expectPaintOrderToMatch,
+	expectShapesToMatch,
+	renderBluefish,
+	renderBluefishSvg,
+	renderModular,
+	renderModularSvg,
+} from "./harness.ts";
+
+// Fixtures for the gaps closed after the initial parity suite: zOrder,
+// Image, stack/distribute total modes, Line, perfect-arrows Arrow geometry,
+// and Circle cx/cy. See PARITY.md.
+
+describe("zOrder", () => {
+	it("controls paint order like Bluefish", async () => {
+		const reference = await renderBluefish((bf) => [
+			bf.Group({}, [
+				bf.Circle({ name: "a", cx: 20, cy: 20, r: 15, zOrder: 2 }),
+				bf.Circle({ name: "b", cx: 35, cy: 20, r: 15, zOrder: 1 }),
+				bf.Circle({ name: "c", cx: 50, cy: 20, r: 15 }),
+			]),
+		]);
+		const { shapes: actual } = renderModularSvg({
+			type: "Group",
+			id: "g",
+			children: [
+				{
+					type: "Circle",
+					id: "a",
+					props: { cx: 20, cy: 20, r: 15, zOrder: 2 },
+				},
+				{
+					type: "Circle",
+					id: "b",
+					props: { cx: 35, cy: 20, r: 15, zOrder: 1 },
+				},
+				{ type: "Circle", id: "c", props: { cx: 50, cy: 20, r: 15 } },
+			],
+		});
+		expectPaintOrderToMatch(actual, reference);
+	});
+});
+
+describe("Image", () => {
+	it("lays out like a rect in a stack", async () => {
+		const reference = await renderBluefish((bf) =>
+			bf.StackH({ spacing: 12 }, [
+				bf.Image({ width: 40, height: 30, href: "cat.png" }),
+				bf.Rect({ width: 20, height: 50 }),
+			]),
+		);
+		const actual = renderModular({
+			type: "StackH",
+			id: "s",
+			props: { spacing: 12 },
+			children: [
+				{
+					type: "Image",
+					id: "i",
+					props: { width: 40, height: 30, href: "cat.png" },
+				},
+				{ type: "Rect", id: "r", props: { width: 20, height: 50 } },
+			],
+		});
+		expectShapesToMatch(actual, reference);
+	});
+});
+
+describe("stack total modes", () => {
+	const rects = [
+		{ width: 30, height: 20 },
+		{ width: 50, height: 40 },
+		{ width: 20, height: 30 },
+	];
+
+	it("total only computes the spacing", async () => {
+		const reference = await renderBluefish((bf) =>
+			bf.StackH(
+				{ total: 200 },
+				rects.map((r) => bf.Rect(r)),
+			),
+		);
+		const actual = renderModular({
+			type: "StackH",
+			id: "s",
+			props: { total: 200 },
+			children: rects.map((r, i) => ({ type: "Rect", id: `r${i}`, props: r })),
+		});
+		expectShapesToMatch(actual, reference);
+	});
+
+	it("total + spacing assigns leftover extent to unsized children", async () => {
+		const reference = await renderBluefish((bf) =>
+			bf.StackH({ total: 200, spacing: 10 }, [
+				bf.Rect({ width: 30, height: 20 }),
+				bf.Rect({ height: 20 }),
+				bf.Rect({ width: 50, height: 20 }),
+			]),
+		);
+		const actual = renderModular({
+			type: "StackH",
+			id: "s",
+			props: { total: 200, spacing: 10 },
+			children: [
+				{ type: "Rect", id: "a", props: { width: 30, height: 20 } },
+				{ type: "Rect", id: "b", props: { height: 20 } },
+				{ type: "Rect", id: "c", props: { width: 50, height: 20 } },
+			],
+		});
+		expectShapesToMatch(actual, reference);
+	});
+
+	it("distribute with total only computes the spacing", async () => {
+		const reference = await renderBluefish((bf) => [
+			bf.Rect({ name: "a", x: 0, y: 0, width: 40, height: 20 }),
+			bf.Rect({ name: "b", width: 60, height: 35 }),
+			bf.Distribute({ direction: "horizontal", total: 300 }, [
+				bf.Ref({ select: "a" }),
+				bf.Ref({ select: "b" }),
+			]),
+		]);
+		const actual = renderModular({
+			type: "Group",
+			id: "root",
+			children: [
+				{ type: "Rect", id: "a", props: { x: 0, y: 0, width: 40, height: 20 } },
+				{ type: "Rect", id: "b", props: { width: 60, height: 35 } },
+				{
+					type: "Distribute",
+					id: "d",
+					props: { direction: "horizontal", total: 300 },
+					children: [
+						{ type: "Ref", target: "a" },
+						{ type: "Ref", target: "b" },
+					],
+				},
+			],
+		});
+		expectShapesToMatch(actual, reference);
+	});
+});
+
+describe("Line", () => {
+	const lineScene = (
+		source: number[] | undefined,
+		target: number[] | undefined,
+	) => ({
+		type: "Group",
+		id: "root",
+		children: [
+			{
+				type: "Rect",
+				id: "a",
+				props: { x: 0, y: 0, width: 40, height: 30, "stroke-width": 0 },
+			},
+			{
+				type: "Rect",
+				id: "b",
+				props: { x: 100, y: 80, width: 40, height: 30, "stroke-width": 0 },
+			},
+			{
+				type: "Line",
+				id: "l",
+				props: { ...(source ? { source } : {}), ...(target ? { target } : {}) },
+				children: [
+					{ type: "Ref", target: "a" },
+					{ type: "Ref", target: "b" },
+				],
+			},
+		],
+	});
+
+	const lineDiagram =
+		(source: number[] | undefined, target: number[] | undefined) =>
+		// biome-ignore lint/suspicious/noExplicitAny: bluefish module type
+		(bf: any) => [
+			bf.Rect({ name: "a", x: 0, y: 0, width: 40, height: 30 }),
+			bf.Rect({ name: "b", x: 100, y: 80, width: 40, height: 30 }),
+			bf.Line(
+				{ ...(source ? { source } : {}), ...(target ? { target } : {}) },
+				[bf.Ref({ select: "a" }), bf.Ref({ select: "b" })],
+			),
+		];
+
+	it("with explicit fractional source and target anchors", async () => {
+		const reference = await renderBluefish(lineDiagram([0.5, 1], [0.5, 0]));
+		const { shapes: actual } = renderModularSvg(lineScene([0.5, 1], [0.5, 0]));
+		expectShapesToMatch(actual, reference);
+	});
+
+	it("with only a source anchor (target clamped)", async () => {
+		const reference = await renderBluefish(lineDiagram([1, 0.5], undefined));
+		const { shapes: actual } = renderModularSvg(lineScene([1, 0.5], undefined));
+		expectShapesToMatch(actual, reference);
+	});
+
+	it("with no anchors (center-biased boundary points)", async () => {
+		const reference = await renderBluefish(lineDiagram(undefined, undefined));
+		const { shapes: actual } = renderModularSvg(
+			lineScene(undefined, undefined),
+		);
+		expectShapesToMatch(actual, reference);
+	});
+});
+
+describe("Arrow (perfect-arrows geometry)", () => {
+	function quadNumbers(svg: string): number[] {
+		const m =
+			/d="M(-?[\d.e+]+),(-?[\d.e+]+) Q(-?[\d.e+]+),(-?[\d.e+]+) (-?[\d.e+]+),(-?[\d.e+]+)"/.exec(
+				svg,
+			);
+		if (!m) throw new Error(`no quadratic path in svg: ${svg.slice(0, 300)}`);
+		return m.slice(1).map(Number);
+	}
+
+	function polygonParts(svg: string): { points: string; transform: number[] } {
+		const m =
+			/<polygon points="([^"]+)" transform="translate\((-?[\d.e+]+),\s*(-?[\d.e+]+)\) rotate\((-?[\d.e+]+)\)"/.exec(
+				svg,
+			);
+		if (!m) throw new Error(`no polygon in svg: ${svg.slice(0, 300)}`);
+		return { points: m[1], transform: m.slice(2).map(Number) };
+	}
+
+	// The frame origin is the top-left rect corner (rect "a" sits at 0,0 with
+	// no stroke), letting us compare path coordinates across both systems.
+	function frameOrigin(shapes: { kind: string; x: number; y: number }[]): {
+		ox: number;
+		oy: number;
+	} {
+		const rects = shapes.filter((s) => s.kind === "rect");
+		return {
+			ox: Math.min(...rects.map((r) => r.x)),
+			oy: Math.min(...rects.map((r) => r.y)),
+		};
+	}
+
+	it("matches Bluefish's curved arrow exactly", async () => {
+		const { svg: refSvg, shapes: refShapes } = await renderBluefishSvg(
+			// biome-ignore lint/suspicious/noExplicitAny: bluefish module type
+			(bf: any) => [
+				bf.Rect({ name: "a", x: 0, y: 0, width: 40, height: 30 }),
+				bf.Rect({ name: "b", x: 120, y: 90, width: 40, height: 30 }),
+				bf.Arrow({}, [bf.Ref({ select: "a" }), bf.Ref({ select: "b" })]),
+			],
+		);
+		const { svg: actSvg, shapes: actShapes } = renderModularSvg({
+			type: "Group",
+			id: "root",
+			children: [
+				{
+					type: "Rect",
+					id: "a",
+					props: { x: 0, y: 0, width: 40, height: 30, "stroke-width": 0 },
+				},
+				{
+					type: "Rect",
+					id: "b",
+					props: { x: 120, y: 90, width: 40, height: 30, "stroke-width": 0 },
+				},
+				{
+					type: "Arrow",
+					id: "arrow",
+					children: [
+						{ type: "Ref", target: "a" },
+						{ type: "Ref", target: "b" },
+					],
+				},
+			],
+		});
+
+		const refO = frameOrigin(refShapes);
+		const actO = frameOrigin(actShapes);
+		const refQuad = quadNumbers(refSvg);
+		const actQuad = quadNumbers(actSvg);
+		for (let i = 0; i < 6; i++) {
+			const refV = refQuad[i] - (i % 2 === 0 ? refO.ox : refO.oy);
+			const actV = actQuad[i] - (i % 2 === 0 ? actO.ox : actO.oy);
+			expect(actV).toBeCloseTo(refV, 3);
+		}
+
+		const refPoly = polygonParts(refSvg);
+		const actPoly = polygonParts(actSvg);
+		expect(actPoly.points).toBe(refPoly.points);
+		expect(actPoly.transform[0] - actO.ox).toBeCloseTo(
+			refPoly.transform[0] - refO.ox,
+			3,
+		);
+		expect(actPoly.transform[1] - actO.oy).toBeCloseTo(
+			refPoly.transform[1] - refO.oy,
+			3,
+		);
+		expect(actPoly.transform[2]).toBeCloseTo(refPoly.transform[2], 3);
+	});
+});
+
+describe("Circle cx/cy", () => {
+	it("center-anchored circles match", async () => {
+		const reference = await renderBluefish((bf) => [
+			bf.Rect({ name: "o", x: 0, y: 0, width: 10, height: 10 }),
+			bf.Circle({ name: "c", cx: 50, cy: 30, r: 10 }),
+		]);
+		const actual = renderModular({
+			type: "Group",
+			id: "root",
+			children: [
+				{ type: "Rect", id: "o", props: { x: 0, y: 0, width: 10, height: 10 } },
+				{ type: "Circle", id: "c", props: { cx: 50, cy: 30, r: 10 } },
+			],
+		});
+		expectShapesToMatch(actual, reference);
+	});
+});

--- a/packages/modular-svg-core/package.json
+++ b/packages/modular-svg-core/package.json
@@ -16,7 +16,8 @@
 	},
 	"license": "MIT",
 	"dependencies": {
-		"ajv": "^8.20.0"
+		"ajv": "^8.20.0",
+		"perfect-arrows": "^0.3.7"
 	},
 	"devDependencies": {
 		"@types/node": "^26.1.1",

--- a/packages/modular-svg-core/src/fuzz.spec.ts
+++ b/packages/modular-svg-core/src/fuzz.spec.ts
@@ -45,7 +45,11 @@ const textNodeArb = fc
 	.record({ text: textArb })
 	.map((props) => ({ type: "Text", props }));
 
-const leafArb = fc.oneof(rectArb, circleArb, textNodeArb);
+const imageArb = fc
+	.record({ width: sizeArb, height: sizeArb })
+	.map((props) => ({ type: "Image", props: { ...props, href: "img.png" } }));
+
+const leafArb = fc.oneof(rectArb, circleArb, textNodeArb, imageArb);
 
 type JsonNode = Record<string, unknown>;
 
@@ -176,7 +180,7 @@ function leafSize(leaf: { type: string; props: Record<string, unknown> }): {
 	width: number;
 	height: number;
 } {
-	if (leaf.type === "Rect") {
+	if (leaf.type === "Rect" || leaf.type === "Image") {
 		return {
 			width: leaf.props.width as number,
 			height: leaf.props.height as number,

--- a/packages/modular-svg-core/src/output.spec.ts
+++ b/packages/modular-svg-core/src/output.spec.ts
@@ -69,6 +69,24 @@ describe("layoutToSvg", () => {
 		expect(svg).toContain('font-family="sans-serif"');
 	});
 
+	it("passes extra SVG attributes through", () => {
+		const nodes: NodeRecord[] = [
+			{
+				id: "R",
+				type: "rect",
+				x: 0,
+				y: 0,
+				width: 10,
+				height: 10,
+				attrs: { rx: 10, "data-label": "a<b" },
+			},
+		];
+		const layout: LayoutResult = { R: { x: 0, y: 0, width: 10, height: 10 } };
+		const svg = layoutToSvg(layout, nodes);
+		expect(svg).toContain('rx="10"');
+		expect(svg).toContain('data-label="a&lt;b"');
+	});
+
 	it("renders arrows", () => {
 		const nodes: NodeRecord[] = [
 			{ id: "A", x: 0, y: 0, width: 10, height: 10 },
@@ -90,7 +108,7 @@ describe("layoutToSvg", () => {
 			L: { x: 0, y: 0, width: 0, height: 0 },
 		};
 		const svg = layoutToSvg(layout, nodes);
-		expect(svg).toContain('<line id="L"');
+		expect(svg).toContain('<path id="L"');
 		expect(svg).toContain("<polygon");
 		expect(svg).not.toContain("marker-end");
 		expect(svg).toContain('stroke-width="3"');

--- a/packages/modular-svg-core/src/output.ts
+++ b/packages/modular-svg-core/src/output.ts
@@ -45,6 +45,7 @@ function serializeElement(element: SvgElement): string {
 			fill: element.fill,
 			stroke: element.stroke,
 			"stroke-width": element.strokeWidth,
+			...element.attrs,
 		});
 	}
 
@@ -57,6 +58,7 @@ function serializeElement(element: SvgElement): string {
 			fill: element.fill,
 			stroke: element.stroke,
 			"stroke-width": element.strokeWidth,
+			...element.attrs,
 		});
 	}
 
@@ -72,6 +74,7 @@ function serializeElement(element: SvgElement): string {
 				fill: element.fill,
 				stroke: element.stroke,
 				"stroke-width": element.strokeWidth,
+				...element.attrs,
 			},
 			escapeXml(element.text),
 		);
@@ -87,6 +90,7 @@ function serializeElement(element: SvgElement): string {
 			fill: element.fill,
 			stroke: element.stroke,
 			"stroke-width": element.strokeWidth,
+			...element.attrs,
 		});
 	}
 
@@ -94,9 +98,34 @@ function serializeElement(element: SvgElement): string {
 		return xml("polygon", {
 			id: element.id,
 			points: element.points,
+			transform: element.transform,
 			fill: element.fill,
 			stroke: element.stroke,
 			"stroke-width": element.strokeWidth,
+			...element.attrs,
+		});
+	}
+
+	if (element.type === "path") {
+		return xml("path", {
+			id: element.id,
+			d: element.d,
+			fill: element.fill,
+			stroke: element.stroke,
+			"stroke-width": element.strokeWidth,
+			...element.attrs,
+		});
+	}
+
+	if (element.type === "image") {
+		return xml("image", {
+			id: element.id,
+			x: element.x,
+			y: element.y,
+			width: element.width,
+			height: element.height,
+			href: element.href,
+			...element.attrs,
 		});
 	}
 

--- a/packages/modular-svg-core/src/parser.ts
+++ b/packages/modular-svg-core/src/parser.ts
@@ -188,6 +188,54 @@ export function buildSceneFromJson(json: Record<string, unknown>): JsonScene {
 		return id;
 	}
 
+	// Props consumed by layout; everything else passes through as SVG attrs
+	const LAYOUT_PROPS = new Set([
+		"x",
+		"y",
+		"width",
+		"height",
+		"r",
+		"cx",
+		"cy",
+		"text",
+		"spacing",
+		"alignment",
+		"axis",
+		"direction",
+		"padding",
+		"total",
+		"zOrder",
+		"source",
+		"target",
+		"href",
+		"fill",
+		"stroke",
+		"stroke-width",
+		"bow",
+		"stretch",
+		"stretchMin",
+		"stretchMax",
+		"padStart",
+		"padEnd",
+		"flip",
+		"straights",
+		"start",
+	]);
+
+	function extraAttrs(
+		props: Record<string, unknown>,
+	): Record<string, string | number> | undefined {
+		let attrs: Record<string, string | number> | undefined;
+		for (const [k, v] of Object.entries(props)) {
+			if (LAYOUT_PROPS.has(k)) continue;
+			if (typeof v !== "string" && typeof v !== "number") continue;
+			if (!/^[a-zA-Z_][\w:.-]*$/.test(k)) continue;
+			if (attrs === undefined) attrs = {};
+			attrs[k] = v;
+		}
+		return attrs;
+	}
+
 	function ensureNode(n: AnyNode, path: string): NodeRecord {
 		if (n.type === "Ref") {
 			const target = nodeMap.get(n.target as string);
@@ -200,47 +248,51 @@ export function buildSceneFromJson(json: Record<string, unknown>): JsonScene {
 		if (existing) return existing;
 		let rec: NodeRecord;
 		const props = (n.props ?? {}) as Record<string, unknown>;
+		const common = {
+			id: nodeId,
+			fill: props.fill as string | undefined,
+			stroke: props.stroke as string | undefined,
+			zOrder: props.zOrder as number | undefined,
+			attrs: extraAttrs(props),
+		};
 		if (n.type === "Rect") {
 			rec = {
-				id: nodeId,
+				...common,
 				type: "rect",
 				x: (props.x as number | undefined) ?? 0,
 				y: (props.y as number | undefined) ?? 0,
 				width: (props.width as number | undefined) ?? 0,
 				height: (props.height as number | undefined) ?? 0,
-				fill: props.fill as string | undefined,
-				stroke: props.stroke as string | undefined,
 				strokeWidth: (props["stroke-width"] as number | undefined) ?? 3,
 			};
 		} else if (n.type === "Background") {
 			rec = {
-				id: nodeId,
+				...common,
 				type: "rect",
 				x: 0,
 				y: 0,
 				width: 0,
 				height: 0,
-				fill: props.fill as string | undefined,
-				stroke: props.stroke as string | undefined,
 				strokeWidth: (props["stroke-width"] as number | undefined) ?? 3,
 			};
 		} else if (n.type === "Circle") {
 			const r = (props.r as number | undefined) ?? 0;
+			// Bluefish circles are center-anchored (cx/cy); top-left x/y also works
+			const cx = props.cx as number | undefined;
+			const cy = props.cy as number | undefined;
 			rec = {
-				id: nodeId,
+				...common,
 				type: "circle",
 				r,
-				x: (props.x as number | undefined) ?? 0,
-				y: (props.y as number | undefined) ?? 0,
+				x: cx !== undefined ? cx - r : ((props.x as number | undefined) ?? 0),
+				y: cy !== undefined ? cy - r : ((props.y as number | undefined) ?? 0),
 				width: r * 2,
 				height: r * 2,
-				fill: props.fill as string | undefined,
-				stroke: props.stroke as string | undefined,
-				strokeWidth: (props["stroke-width"] as number | undefined) ?? 1,
+				strokeWidth: props["stroke-width"] as number | undefined,
 			};
 		} else if (n.type === "Text") {
 			rec = {
-				id: nodeId,
+				...common,
 				type: "text",
 				text: (props.text as string | undefined) ?? "",
 				x: (props.x as number | undefined) ?? 0,
@@ -250,27 +302,83 @@ export function buildSceneFromJson(json: Record<string, unknown>): JsonScene {
 					((props.text as string | undefined)?.length ?? 0) * 8,
 				height: (props.height as number | undefined) ?? 16,
 				fill: (props.fill as string | undefined) ?? "black",
-				stroke: props.stroke as string | undefined,
 				strokeWidth: props["stroke-width"] as number | undefined,
+			};
+		} else if (n.type === "Image") {
+			rec = {
+				...common,
+				type: "image",
+				href: props.href as string | undefined,
+				x: (props.x as number | undefined) ?? 0,
+				y: (props.y as number | undefined) ?? 0,
+				width: (props.width as number | undefined) ?? 0,
+				height: (props.height as number | undefined) ?? 0,
 			};
 		} else if (n.type === "Arrow") {
 			rec = {
-				id: nodeId,
+				...common,
 				type: "arrow",
 				x: 0,
 				y: 0,
 				width: 0,
 				height: 0,
-				fill: props.fill as string | undefined,
-				stroke: props.stroke as string | undefined,
+				strokeWidth: (props["stroke-width"] as number | undefined) ?? 3,
+				// perfect-arrows options, defaults matching Bluefish
+				arrow: {
+					bow: (props.bow as number | undefined) ?? 0.2,
+					stretch: (props.stretch as number | undefined) ?? 0.5,
+					stretchMin: (props.stretchMin as number | undefined) ?? 40,
+					stretchMax: (props.stretchMax as number | undefined) ?? 420,
+					padStart: (props.padStart as number | undefined) ?? 5,
+					padEnd: (props.padEnd as number | undefined) ?? 20,
+					flip: (props.flip as boolean | undefined) ?? false,
+					straights: (props.straights as boolean | undefined) ?? true,
+					start: (props.start as boolean | undefined) ?? false,
+				},
+			};
+		} else if (n.type === "Line") {
+			rec = {
+				...common,
+				type: "line",
+				x: 0,
+				y: 0,
+				width: 0,
+				height: 0,
+				source: props.source as number[] | undefined,
+				target: props.target as number[] | undefined,
+				stroke: (props.stroke as string | undefined) ?? "black",
 				strokeWidth: (props["stroke-width"] as number | undefined) ?? 3,
 			};
 		} else {
-			rec = { id: nodeId, x: 0, y: 0, width: 0, height: 0 };
+			rec = {
+				id: nodeId,
+				x: 0,
+				y: 0,
+				width: 0,
+				height: 0,
+				zOrder: props.zOrder as number | undefined,
+			};
 		}
-		if (n.type === "Rect" || n.type === "Circle" || n.type === "Text") {
-			if (props.x !== undefined) userOwned.add(`${nodeId}:x`);
-			if (props.y !== undefined) userOwned.add(`${nodeId}:y`);
+		if (
+			n.type === "Rect" ||
+			n.type === "Circle" ||
+			n.type === "Text" ||
+			n.type === "Image"
+		) {
+			if (props.x !== undefined || props.cx !== undefined)
+				userOwned.add(`${nodeId}:x`);
+			if (props.y !== undefined || props.cy !== undefined)
+				userOwned.add(`${nodeId}:y`);
+			// Extent ownership: explicit sizes, a circle's radius, and text's
+			// measured size all count as owned (matching Bluefish)
+			if (props.width !== undefined || n.type === "Circle" || n.type === "Text")
+				userOwned.add(`${nodeId}:w`);
+			if (
+				props.height !== undefined ||
+				n.type === "Circle" ||
+				n.type === "Text"
+			)
+				userOwned.add(`${nodeId}:h`);
 		}
 		nodeMap.set(rec.id, rec);
 		nodes.push(rec);
@@ -305,12 +413,14 @@ export function buildSceneFromJson(json: Record<string, unknown>): JsonScene {
 				});
 				descs.push({ kind: "union", container: rec, children });
 			} else if (node.type === "Distribute") {
+				// Bluefish uses direction horizontal/vertical; axis x/y also works
+				const raw =
+					(node.props?.axis as string) ??
+					(node.props?.direction as string) ??
+					"x";
 				descs.push({
 					kind: "distribute",
-					axis:
-						(node.props?.axis as "x" | "y") ??
-						(node.props?.direction as "x" | "y") ??
-						"x",
+					axis: raw === "y" || raw === "vertical" ? "y" : "x",
 					children,
 					props: node.props ?? {},
 				});
@@ -323,7 +433,10 @@ export function buildSceneFromJson(json: Record<string, unknown>): JsonScene {
 					// Default padding matches Bluefish
 					padding: (node.props?.padding as number) ?? 10,
 				});
-			} else if (node.type === "Arrow" && children.length >= 2) {
+			} else if (
+				(node.type === "Arrow" || node.type === "Line") &&
+				children.length >= 2
+			) {
 				(rec as NodeRecord).from = children[0].id;
 				(rec as NodeRecord).to = children[1].id;
 				descs.push({ kind: "union", container: rec, children });
@@ -397,40 +510,88 @@ export function buildSceneFromJson(json: Record<string, unknown>): JsonScene {
 		}
 	}
 
+	function extentOwnedOf(children: NodeRecord[], axis: "w" | "h"): boolean[] {
+		return children.map((c) => {
+			const key = `${c.id}:${axis}`;
+			return hardOwned.has(key) || userOwned.has(key);
+		});
+	}
+
+	// Handle the Bluefish sizing modes' ownership effects: in total+spacing
+	// mode unowned extents get assigned (and become owned); the other exact
+	// modes require every extent to be owned already.
+	function claimExtents(
+		relation: string,
+		children: NodeRecord[],
+		axis: "w" | "h",
+		spacing: number | undefined,
+		total: number | undefined,
+		extentOwned: boolean[],
+	): void {
+		if (spacing !== undefined && total !== undefined) {
+			children.forEach((c, i) => {
+				if (!extentOwned[i]) hardOwned.add(`${c.id}:${axis}`);
+			});
+		} else if (spacing !== undefined || total !== undefined) {
+			children.forEach((c, i) => {
+				if (!extentOwned[i]) {
+					warnings.push(
+						`${relation}: ${axis === "w" ? "width" : "height"} of ${c.id} is not owned`,
+					);
+				}
+			});
+		}
+	}
+
 	const ops: LayoutOperator[] = [];
 	for (const d of descs) {
 		if (d.kind === "stackV" || d.kind === "stackH") {
 			const mainAxis = d.kind === "stackV" ? "y" : "x";
 			const crossAxis = d.kind === "stackV" ? "x" : "y";
+			const extentAxis = d.kind === "stackV" ? "h" : "w";
 			const mainAnchor = anchorIndex(d.children, mainAxis);
 			const crossAnchor = anchorIndex(d.children, crossAxis);
 			claim(d.children, mainAxis, mainAnchor, d.container.id);
 			claim(d.children, crossAxis, crossAnchor, d.container.id);
+			// Defaults match Bluefish: spacing 10 only when total is also unset
+			const spacingProp = d.props.spacing as number | undefined;
+			const total = d.props.total as number | undefined;
+			const spacing =
+				spacingProp === undefined && total === undefined ? 10 : spacingProp;
+			const extentOwned = extentOwnedOf(d.children, extentAxis);
+			claimExtents(
+				d.container.id,
+				d.children,
+				extentAxis,
+				spacing,
+				total,
+				extentOwned,
+			);
+			hardOwned.add(`${d.container.id}:w`);
+			hardOwned.add(`${d.container.id}:h`);
 			const children = toSubtreeChildren(d.children);
 			const containerIdx = baseOf(d.container);
-			// Defaults match Bluefish: spacing 10, centered cross-axis alignment
-			const spacing = (d.props.spacing as number) ?? 10;
 			if (d.kind === "stackV") {
 				ops.push(
-					stackV(
-						children,
-						containerIdx,
+					stackV(children, containerIdx, {
 						spacing,
-						(d.props.alignment as AlignmentX) ?? "centerX",
+						total,
+						alignment: (d.props.alignment as AlignmentX) ?? "centerX",
 						mainAnchor,
 						crossAnchor,
-					),
+						extentOwned,
+					}),
 				);
 			} else {
 				ops.push(
-					stackH(
-						children,
-						containerIdx,
+					stackH(children, containerIdx, {
 						spacing,
-						(d.props.alignment as AlignmentY) ?? "centerY",
+						total,
+						alignment: (d.props.alignment as AlignmentY) ?? "centerY",
 						mainAnchor,
 						crossAnchor,
-					),
+						extentOwned,
+					}),
 				);
 			}
 		} else if (d.kind === "align") {
@@ -445,14 +606,29 @@ export function buildSceneFromJson(json: Record<string, unknown>): JsonScene {
 				}
 			}
 		} else if (d.kind === "distribute") {
-			const spacing = (d.props.spacing as number | undefined) ?? 0;
+			const spacing = d.props.spacing as number | undefined;
+			const total = d.props.total as number | undefined;
+			const exactMode = spacing !== undefined || total !== undefined;
+			const extentAxis = d.axis === "x" ? "w" : "h";
 			const anchor = anchorIndex(d.children, d.axis) ?? 0;
-			claim(d.children, d.axis, spacing > 0 ? anchor : null, "distribute");
+			claim(d.children, d.axis, exactMode ? anchor : null, "distribute");
+			const extentOwned = extentOwnedOf(d.children, extentAxis);
+			claimExtents(
+				"distribute",
+				d.children,
+				extentAxis,
+				spacing,
+				total,
+				extentOwned,
+			);
 			const children = toSubtreeChildren(d.children);
-			if (d.axis === "x") ops.push(distributeX(children, spacing, anchor));
-			else ops.push(distributeY(children, spacing, anchor));
+			const opts = { spacing, total, anchor, extentOwned };
+			if (d.axis === "x") ops.push(distributeX(children, opts));
+			else ops.push(distributeY(children, opts));
 		} else if (d.kind === "background") {
 			ops.push(backgroundOp(baseOf(d.child), baseOf(d.box), d.padding));
+			hardOwned.add(`${d.box.id}:w`);
+			hardOwned.add(`${d.box.id}:h`);
 		} else if (d.kind === "union") {
 			ops.push(
 				unionOp(
@@ -460,6 +636,8 @@ export function buildSceneFromJson(json: Record<string, unknown>): JsonScene {
 					baseOf(d.container),
 				),
 			);
+			hardOwned.add(`${d.container.id}:w`);
+			hardOwned.add(`${d.container.id}:h`);
 		}
 	}
 

--- a/packages/modular-svg-core/src/planet.spec.ts
+++ b/packages/modular-svg-core/src/planet.spec.ts
@@ -117,23 +117,25 @@ describe("planet example", () => {
 		);
 	});
 
-	it("arrow points above mercury with margin", () => {
+	it("arrow curves from the label to above mercury", () => {
 		const label = layout.label;
 		const mercury = layout.mercury;
-		// compute arrow endpoints using svg output
+		// compute arrow endpoints from the quadratic path in the svg output
 		const svg = layoutToSvg(layout, scene.nodes);
-		const lineMatch = new RegExp(`<line id="${arrowId}"[^>]+>`).exec(svg);
-		expect(lineMatch).not.toBeNull();
-		if (lineMatch) {
-			const attrs = lineMatch[0];
-			const y1 = Number(/y1="([^"]+)"/.exec(attrs)?.[1] ?? 0);
-			const y2 = Number(/y2="([^"]+)"/.exec(attrs)?.[1] ?? 0);
-			const dy = Math.max(
-				0,
-				-Math.min(...Object.values(layout).map((b) => b.y)),
-			);
-			expect(y1).toBeGreaterThan(label.y + dy + label.height);
-			expect(y2).toBeLessThan(mercury.y + dy);
+		const pathMatch = new RegExp(`<path id="${arrowId}"[^>]+>`).exec(svg);
+		expect(pathMatch).not.toBeNull();
+		if (pathMatch) {
+			const attrs = pathMatch[0];
+			const d = /d="M([^,]+),([^ ]+) Q[^ ]+ ([^,]+),([^"]+)"/.exec(attrs);
+			expect(d).not.toBeNull();
+			if (d) {
+				const [, , sy, , ey] = d.map(Number);
+				const min = Math.min(...Object.values(layout).map((b) => b.y));
+				const dy = -min;
+				// starts at or below the label, ends above mercury's top edge
+				expect(sy).toBeGreaterThan(label.y + dy);
+				expect(ey).toBeLessThan(mercury.y + dy);
+			}
 			expect(attrs).toContain('stroke-width="3"');
 		}
 		expect(svg).toContain("<polygon");

--- a/packages/modular-svg-core/src/scene.schema.json
+++ b/packages/modular-svg-core/src/scene.schema.json
@@ -16,7 +16,9 @@
 				"Distribute",
 				"Ref",
 				"Text",
-				"Arrow"
+				"Arrow",
+				"Line",
+				"Image"
 			]
 		},
 		"id": { "type": "string" },
@@ -28,7 +30,10 @@
 				"x": { "type": "number" },
 				"y": { "type": "number" },
 				"r": { "type": "number" },
+				"cx": { "type": "number" },
+				"cy": { "type": "number" },
 				"spacing": { "type": "number" },
+				"total": { "type": "number" },
 				"alignment": { "type": "string" },
 				"axis": { "type": "string" },
 				"direction": { "type": "string" },
@@ -36,7 +41,30 @@
 				"stroke": { "type": "string" },
 				"stroke-width": { "type": "number" },
 				"text": { "type": "string" },
-				"padding": { "type": "number" }
+				"padding": { "type": "number" },
+				"zOrder": { "type": "number" },
+				"href": { "type": "string" },
+				"source": {
+					"type": "array",
+					"items": { "type": "number" },
+					"minItems": 2,
+					"maxItems": 2
+				},
+				"target": {
+					"type": "array",
+					"items": { "type": "number" },
+					"minItems": 2,
+					"maxItems": 2
+				},
+				"bow": { "type": "number" },
+				"stretch": { "type": "number" },
+				"stretchMin": { "type": "number" },
+				"stretchMax": { "type": "number" },
+				"padStart": { "type": "number" },
+				"padEnd": { "type": "number" },
+				"flip": { "type": "boolean" },
+				"straights": { "type": "boolean" },
+				"start": { "type": "boolean" }
 			},
 			"additionalProperties": true
 		},

--- a/packages/modular-svg-core/src/solver/distribute.spec.ts
+++ b/packages/modular-svg-core/src/solver/distribute.spec.ts
@@ -11,7 +11,7 @@ describe("Distribute operator", () => {
 			{ id: "C", x: 30, y: 0, width: 0, height: 0 },
 		];
 		const children = nodes.map((_n, i) => ({ base: i * 4, subtree: [i * 4] }));
-		const op = distributeX(children, 0, 0);
+		const op = distributeX(children);
 		const scene = { nodes, operators: [op as LayoutOperator] };
 		const result = solveLayout(scene, { damping: 1 });
 		expect(result.B.x).toBeCloseTo(15);

--- a/packages/modular-svg-core/src/solver/operators.ts
+++ b/packages/modular-svg-core/src/solver/operators.ts
@@ -1,21 +1,45 @@
 export type LayoutOperator = (cur: Float64Array, next: Float64Array) => void;
 
+export type ArrowGeometry = {
+	bow: number;
+	stretch: number;
+	stretchMin: number;
+	stretchMax: number;
+	padStart: number;
+	padEnd: number;
+	flip: boolean;
+	straights: boolean;
+	/** paint a dot at the arrow start */
+	start: boolean;
+};
+
 export type NodeRecord = {
 	id: string;
 	x: number;
 	y: number;
 	width: number;
 	height: number;
-	type?: "rect" | "circle" | "text" | "arrow";
+	type?: "rect" | "circle" | "text" | "arrow" | "image" | "line";
 	r?: number;
 	text?: string;
-	/** id of source node for arrows */
+	href?: string;
+	/** id of source node for arrows and lines */
 	from?: string;
-	/** id of target node for arrows */
+	/** id of target node for arrows and lines */
 	to?: string;
+	/** fractional [0..1, 0..1] bbox anchor for the line start */
+	source?: number[];
+	/** fractional [0..1, 0..1] bbox anchor for the line end */
+	target?: number[];
+	/** perfect-arrows options for arrows */
+	arrow?: ArrowGeometry;
 	fill?: string;
 	stroke?: string;
 	strokeWidth?: number;
+	/** paint order; higher paints later (on top). Default 0. */
+	zOrder?: number;
+	/** extra SVG attributes passed through to the emitted element */
+	attrs?: Record<string, string | number>;
 };
 
 // A relation child: the node's own slot base plus the bases of every node in
@@ -112,6 +136,54 @@ function writeUnion(
 	next[containerIndex + 3] = maxY - minY;
 }
 
+export type StackOptions = {
+	spacing?: number;
+	total?: number;
+	alignment: AlignmentX | AlignmentY;
+	mainAnchor?: number | null;
+	crossAnchor?: number | null;
+	/** whether each child's main-axis extent is owned (user prop or relation) */
+	extentOwned?: readonly boolean[];
+};
+
+// Resolve the three Bluefish sizing modes into effective extents + gap.
+// spacing+total: children with unowned extents share (total - sum of owned
+// extents) - note Bluefish does NOT subtract the spacing gaps here, a quirk
+// we preserve. total only: gap = leftover / (n-1). spacing only: extents as
+// they are. Assigned extents are written to the child's extent slot.
+function resolveExtents(
+	cur: Float64Array,
+	next: Float64Array,
+	children: readonly SubtreeChild[],
+	extentSlot: number,
+	spacing: number | undefined,
+	total: number | undefined,
+	extentOwned: readonly boolean[] | undefined,
+): { extents: number[]; gap: number } {
+	const current = children.map((c) => cur[c.base + extentSlot]);
+	if (spacing !== undefined && total !== undefined) {
+		let unassigned = total;
+		let numUnowned = 0;
+		for (let i = 0; i < children.length; i++) {
+			if (extentOwned?.[i]) unassigned -= current[i];
+			else numUnowned++;
+		}
+		const share = numUnowned > 0 ? unassigned / numUnowned : 0;
+		const extents = current.map((e, i) => (extentOwned?.[i] ? e : share));
+		for (let i = 0; i < children.length; i++) {
+			if (!extentOwned?.[i]) next[children[i].base + extentSlot] = share;
+		}
+		return { extents, gap: spacing };
+	}
+	if (total !== undefined) {
+		const occupied = current.reduce((s, e) => s + e, 0);
+		const gap =
+			children.length > 1 ? (total - occupied) / (children.length - 1) : 0;
+		return { extents: current, gap };
+	}
+	return { extents: current, gap: spacing ?? 10 };
+}
+
 // Bluefish-style stack: children are packed along the main axis with fixed
 // spacing and aligned across it. If a child's position is owned by another
 // relation (anchor), the run is placed so that child stays fixed; otherwise
@@ -121,22 +193,32 @@ function stack(
 	horizontal: boolean,
 	children: readonly SubtreeChild[],
 	containerIndex: number,
-	spacing: number,
-	alignment: AlignmentX | AlignmentY,
-	mainAnchor: number | null,
-	crossAnchor: number | null,
+	opts: StackOptions,
 ): LayoutOperator {
+	const { alignment } = opts;
+	const mainAnchor = opts.mainAnchor ?? null;
+	const crossAnchor = opts.crossAnchor ?? null;
 	const mainSlot = horizontal ? 0 : 1;
 	const extentSlot = horizontal ? 2 : 3;
 	return (cur, next) => {
 		if (children.length === 0) return;
 
+		const { extents, gap } = resolveExtents(
+			cur,
+			next,
+			children,
+			extentSlot,
+			opts.spacing,
+			opts.total,
+			opts.extentOwned,
+		);
+
 		// Cumulative offsets along the main axis
 		const offsets: number[] = [];
 		let acc = 0;
-		for (const c of children) {
+		for (const e of extents) {
 			offsets.push(acc);
-			acc += cur[c.base + extentSlot] + spacing;
+			acc += e + gap;
 		}
 
 		const start =
@@ -200,8 +282,9 @@ function stack(
 					? cur[c.base + 1]
 					: targetY,
 			);
-			ws.push(cur[c.base + 2]);
-			hs.push(cur[c.base + 3]);
+			// main-axis extent may have been assigned by a total mode
+			ws.push(horizontal ? extents[i] : cur[c.base + 2]);
+			hs.push(horizontal ? cur[c.base + 3] : extents[i]);
 		}
 
 		writeUnion(next, containerIndex, xs, ys, ws, hs);
@@ -211,39 +294,17 @@ function stack(
 export function stackV(
 	children: readonly SubtreeChild[],
 	containerIndex: number,
-	spacing: number,
-	alignment: AlignmentX,
-	mainAnchor: number | null = null,
-	crossAnchor: number | null = null,
+	opts: StackOptions,
 ): LayoutOperator {
-	return stack(
-		false,
-		children,
-		containerIndex,
-		spacing,
-		alignment,
-		mainAnchor,
-		crossAnchor,
-	);
+	return stack(false, children, containerIndex, opts);
 }
 
 export function stackH(
 	children: readonly SubtreeChild[],
 	containerIndex: number,
-	spacing: number,
-	alignment: AlignmentY,
-	mainAnchor: number | null = null,
-	crossAnchor: number | null = null,
+	opts: StackOptions,
 ): LayoutOperator {
-	return stack(
-		true,
-		children,
-		containerIndex,
-		spacing,
-		alignment,
-		mainAnchor,
-		crossAnchor,
-	);
+	return stack(true, children, containerIndex, opts);
 }
 
 // Bluefish-style align: the anchor child (first child whose position is
@@ -285,27 +346,43 @@ export function alignY(
 	};
 }
 
-// Distribute along an axis. With spacing > 0 the children are packed with
-// exactly that edge-to-edge gap, anchored on the anchor child (first owned,
-// falling back to the first child). With spacing <= 0 the children spread
-// evenly between the current outermost positions (an extension; Bluefish
-// requires spacing or total).
+export type DistributeOptions = {
+	spacing?: number;
+	total?: number;
+	anchor?: number;
+	/** whether each child's main-axis extent is owned (user prop or relation) */
+	extentOwned?: readonly boolean[];
+};
+
+// Distribute along an axis, matching Bluefish's three sizing modes (spacing /
+// total / both), anchored on the anchor child (first owned, falling back to
+// the first child). With neither spacing nor total the children spread evenly
+// between the current outermost positions (an extension; Bluefish throws).
 function distribute(
 	horizontal: boolean,
 	children: readonly SubtreeChild[],
-	spacing: number,
-	anchor: number,
+	opts: DistributeOptions,
 ): LayoutOperator {
+	const anchor = opts.anchor ?? 0;
 	const slot = (horizontal ? 0 : 1) as 0 | 1;
 	const extentSlot = horizontal ? 2 : 3;
 	return (cur, next) => {
 		if (children.length < 2) return;
-		if (spacing > 0) {
+		if (opts.spacing !== undefined || opts.total !== undefined) {
+			const { extents, gap } = resolveExtents(
+				cur,
+				next,
+				children,
+				extentSlot,
+				opts.spacing,
+				opts.total,
+				opts.extentOwned,
+			);
 			const offsets: number[] = [];
 			let acc = 0;
-			for (const c of children) {
+			for (const e of extents) {
 				offsets.push(acc);
-				acc += cur[c.base + extentSlot] + spacing;
+				acc += e + gap;
 			}
 			const start = cur[children[anchor].base + slot] - offsets[anchor];
 			for (let i = 0; i < children.length; i++) {
@@ -345,18 +422,16 @@ function distribute(
 
 export function distributeX(
 	children: readonly SubtreeChild[],
-	spacing = 0,
-	anchor = 0,
+	opts: DistributeOptions = {},
 ): LayoutOperator {
-	return distribute(true, children, spacing, anchor);
+	return distribute(true, children, opts);
 }
 
 export function distributeY(
 	children: readonly SubtreeChild[],
-	spacing = 0,
-	anchor = 0,
+	opts: DistributeOptions = {},
 ): LayoutOperator {
-	return distribute(false, children, spacing, anchor);
+	return distribute(false, children, opts);
 }
 
 export function backgroundOp(

--- a/packages/modular-svg-core/src/solver/property.spec.ts
+++ b/packages/modular-svg-core/src/solver/property.spec.ts
@@ -120,7 +120,7 @@ describe("property based primitives", () => {
 				(boxes, spacing, anchorSeed) => {
 					const anchor = anchorSeed % boxes.length;
 					const { nodes, children } = leafNodes(boxes);
-					const op = distributeX(children, spacing, anchor);
+					const op = distributeX(children, { spacing, anchor });
 					const result = solveLayout(
 						{ nodes, operators: [op as LayoutOperator] },
 						{ damping: 1 },
@@ -141,7 +141,7 @@ describe("property based primitives", () => {
 		fc.assert(
 			fc.property(boxesArb, (boxes) => {
 				const { nodes, children } = leafNodes(boxes);
-				const op = distributeY(children, 0, 0);
+				const op = distributeY(children);
 				const result = solveLayout(
 					{ nodes, operators: [op as LayoutOperator] },
 					{ damping: 1 },
@@ -173,7 +173,10 @@ describe("property based primitives", () => {
 					const { nodes, children } = leafNodes(boxes);
 					const allNodes = [...nodes, container];
 					const containerIdx = nodes.length * 4;
-					const op = stackV(children, containerIdx, spacing, "left");
+					const op = stackV(children, containerIdx, {
+						spacing,
+						alignment: "left",
+					});
 					const result = solveLayout(
 						{ nodes: allNodes, operators: [op as LayoutOperator] },
 						{ damping: 1 },
@@ -219,14 +222,12 @@ describe("property based primitives", () => {
 					const { nodes, children } = leafNodes(boxes);
 					const allNodes = [...nodes, container];
 					const containerIdx = nodes.length * 4;
-					const op = stackH(
-						children,
-						containerIdx,
+					const op = stackH(children, containerIdx, {
 						spacing,
-						"top",
-						anchor,
-						anchor,
-					);
+						alignment: "top",
+						mainAnchor: anchor,
+						crossAnchor: anchor,
+					});
 					const result = solveLayout(
 						{ nodes: allNodes, operators: [op as LayoutOperator] },
 						{ damping: 1 },
@@ -270,7 +271,7 @@ describe("property based primitives", () => {
 						{ base: 8, subtree: [8] }, // sib
 						{ base: 4, subtree: [4, 0] }, // inner + leaf
 					];
-					const op = stackV(children, 12, spacing, "left");
+					const op = stackV(children, 12, { spacing, alignment: "left" });
 					const result = solveLayout(
 						{ nodes, operators: [op as LayoutOperator] },
 						{ damping: 1 },

--- a/packages/modular-svg-core/src/solver/stack.spec.ts
+++ b/packages/modular-svg-core/src/solver/stack.spec.ts
@@ -20,7 +20,7 @@ describe("Stack operator", () => {
 			base: (i + 1) * 4,
 			subtree: [(i + 1) * 4],
 		}));
-		const op = stackV(children, 0, 5, "centerX");
+		const op = stackV(children, 0, { spacing: 5, alignment: "centerX" });
 		const scene = { nodes, operators: [op as LayoutOperator] };
 		const result = solveLayout(scene, { damping: 1 });
 		expect(result.A.y).toBe(0);

--- a/packages/modular-svg-core/src/svg_ast.spec.ts
+++ b/packages/modular-svg-core/src/svg_ast.spec.ts
@@ -57,7 +57,7 @@ describe("SVG AST", () => {
 		expect(rects.length).toBeGreaterThanOrEqual(1);
 	});
 
-	it("generates arrow as line + polygon elements", () => {
+	it("generates arrow as path + polygon elements", () => {
 		const json = {
 			type: "Group",
 			children: [
@@ -78,10 +78,10 @@ describe("SVG AST", () => {
 		const layout = solveLayout(scene);
 		const ast = layoutToAst(layout, scene.nodes, 10);
 
-		const lines = ast.children.filter((el) => el.type === "line");
+		const paths = ast.children.filter((el) => el.type === "path");
 		const polygons = ast.children.filter((el) => el.type === "polygon");
 
-		expect(lines.length).toBe(1);
+		expect(paths.length).toBe(1);
 		expect(polygons.length).toBe(1);
 	});
 

--- a/packages/modular-svg-core/src/svg_ast.ts
+++ b/packages/modular-svg-core/src/svg_ast.ts
@@ -1,17 +1,16 @@
+import { getBoxToBoxArrow } from "perfect-arrows";
 import {
-	addVec,
 	type BoundingBox2d,
 	boundingBoxFromPoints,
 	boundingBoxFromRect,
-	lengthVec,
-	perpVec,
-	scaleVec,
-	subVec,
 	unionBoundingBox2d,
 	type Vec2,
 	vec,
 } from "./math.ts";
 import type { LayoutResult, NodeRecord } from "./solver/index.ts";
+
+// Extra SVG attributes passed through from the scene
+export type PassthroughAttrs = Record<string, string | number>;
 
 // SVG AST Element Types
 export type SvgElement =
@@ -19,7 +18,9 @@ export type SvgElement =
 	| CircleElement
 	| TextElement
 	| LineElement
-	| PolygonElement;
+	| PolygonElement
+	| PathElement
+	| ImageElement;
 
 export type RectElement = {
 	type: "rect";
@@ -31,17 +32,19 @@ export type RectElement = {
 	fill?: string;
 	stroke?: string;
 	strokeWidth?: number;
+	attrs?: PassthroughAttrs;
 };
 
 export type CircleElement = {
 	type: "circle";
-	id: string;
+	id?: string;
 	cx: number;
 	cy: number;
 	r: number;
 	fill?: string;
 	stroke?: string;
 	strokeWidth?: number;
+	attrs?: PassthroughAttrs;
 };
 
 export type TextElement = {
@@ -53,6 +56,7 @@ export type TextElement = {
 	fill?: string;
 	stroke?: string;
 	strokeWidth?: number;
+	attrs?: PassthroughAttrs;
 };
 
 export type LineElement = {
@@ -65,15 +69,39 @@ export type LineElement = {
 	fill?: string;
 	stroke?: string;
 	strokeWidth?: number;
+	attrs?: PassthroughAttrs;
 };
 
 export type PolygonElement = {
 	type: "polygon";
 	id?: string;
 	points: string;
+	transform?: string;
 	fill?: string;
 	stroke?: string;
 	strokeWidth?: number;
+	attrs?: PassthroughAttrs;
+};
+
+export type PathElement = {
+	type: "path";
+	id?: string;
+	d: string;
+	fill?: string;
+	stroke?: string;
+	strokeWidth?: number;
+	attrs?: PassthroughAttrs;
+};
+
+export type ImageElement = {
+	type: "image";
+	id: string;
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+	href?: string;
+	attrs?: PassthroughAttrs;
 };
 
 export type SvgDocument = {
@@ -119,6 +147,7 @@ function getAttrs(n?: NodeRecord): {
 	fill?: string;
 	stroke?: string;
 	strokeWidth?: number;
+	attrs?: PassthroughAttrs;
 } {
 	if (!n) return {};
 	const fill =
@@ -129,6 +158,7 @@ function getAttrs(n?: NodeRecord): {
 		fill,
 		stroke,
 		...(sw !== undefined ? { strokeWidth: sw } : {}),
+		...(n.attrs ? { attrs: n.attrs } : {}),
 	};
 }
 
@@ -192,53 +222,172 @@ function buildText(
 	};
 }
 
-// Build arrow elements (line + polygon)
+// Build image element
+function buildImage(
+	id: string,
+	box: LayoutResult[string],
+	n: NodeRecord,
+	offset: Vec2,
+): ImageElement {
+	return {
+		type: "image",
+		id,
+		x: box.x + offset.x,
+		y: box.y + offset.y,
+		width: box.width,
+		height: box.height,
+		...(n.href !== undefined ? { href: n.href } : {}),
+		...(n.attrs ? { attrs: n.attrs } : {}),
+	};
+}
+
+type Box = { left: number; top: number; right: number; bottom: number };
+
+function toBox(b: LayoutResult[string], offset: Vec2): Box {
+	return {
+		left: b.x + offset.x,
+		top: b.y + offset.y,
+		right: b.x + offset.x + b.width,
+		bottom: b.y + offset.y + b.height,
+	};
+}
+
+const clamp = (num: number, min: number, max: number) =>
+	Math.min(Math.max(num, min), max);
+const lerp = (num: number, min: number, max: number) => min + (max - min) * num;
+
+// Build line element connecting two boxes, ported from Bluefish's Line:
+// fractional source/target anchors; a missing endpoint is the other endpoint
+// clamped into the box; with neither, center-biased boundary points.
+function buildLine(
+	id: string,
+	n: NodeRecord,
+	layout: LayoutResult,
+	offset: Vec2,
+): LineElement | undefined {
+	const a = n.from ? layout[n.from] : undefined;
+	const b = n.to ? layout[n.to] : undefined;
+	if (!a || !b) return;
+	const from = toBox(a, offset);
+	const to = toBox(b, offset);
+
+	let fromX: number;
+	let fromY: number;
+	let toX: number;
+	let toY: number;
+	if (n.source && n.target) {
+		fromX = lerp(n.source[0], from.left, from.right);
+		fromY = lerp(n.source[1], from.top, from.bottom);
+		toX = lerp(n.target[0], to.left, to.right);
+		toY = lerp(n.target[1], to.top, to.bottom);
+	} else if (n.source) {
+		fromX = lerp(n.source[0], from.left, from.right);
+		fromY = lerp(n.source[1], from.top, from.bottom);
+		toX = clamp(fromX, to.left, to.right);
+		toY = clamp(fromY, to.top, to.bottom);
+	} else if (n.target) {
+		toX = lerp(n.target[0], to.left, to.right);
+		toY = lerp(n.target[1], to.top, to.bottom);
+		fromX = clamp(toX, from.left, from.right);
+		fromY = clamp(toY, from.top, from.bottom);
+	} else {
+		// does not necessarily produce the shortest line between the boxes;
+		// biased towards the center of each box's x and y axis (Bluefish quirk)
+		const fromCX = (from.left + from.right) / 2;
+		const fromCY = (from.top + from.bottom) / 2;
+		const toCX = (to.left + to.right) / 2;
+		const toCY = (to.top + to.bottom) / 2;
+		fromX = clamp(clamp(fromCX, to.left, to.right), from.left, from.right);
+		fromY = clamp(clamp(fromCY, to.top, to.bottom), from.top, from.bottom);
+		toX = clamp(clamp(toCX, from.left, from.right), to.left, to.right);
+		toY = clamp(clamp(toCY, from.top, from.bottom), to.top, to.bottom);
+	}
+
+	return {
+		type: "line",
+		id,
+		x1: fromX,
+		y1: fromY,
+		x2: toX,
+		y2: toY,
+		stroke: n.stroke ?? "black",
+		strokeWidth: n.strokeWidth ?? 3,
+		...(n.attrs ? { attrs: n.attrs } : {}),
+	};
+}
+
+// Build arrow elements using perfect-arrows, matching Bluefish's Arrow paint:
+// a quadratic path, a stroke-width-scaled polygon head rotated to the end
+// angle, and an optional start dot.
 function buildArrow(
 	id: string,
 	n: NodeRecord,
 	layout: LayoutResult,
-	shift: Vec2,
-): (LineElement | PolygonElement)[] | undefined {
+	offset: Vec2,
+): SvgElement[] | undefined {
 	const a = n.from ? layout[n.from] : undefined;
 	const b = n.to ? layout[n.to] : undefined;
 	if (!a || !b) return;
+	const opts = n.arrow ?? {
+		bow: 0.2,
+		stretch: 0.5,
+		stretchMin: 40,
+		stretchMax: 420,
+		padStart: 5,
+		padEnd: 20,
+		flip: false,
+		straights: true,
+		start: false,
+	};
 
-	const margin = 5;
-	const start = vec(
-		a.x + shift.x + a.width / 2,
-		a.y + shift.y + a.height + margin,
+	const [sx, sy, cx, cy, ex, ey, ae] = getBoxToBoxArrow(
+		a.x + offset.x,
+		a.y + offset.y,
+		a.width,
+		a.height,
+		b.x + offset.x,
+		b.y + offset.y,
+		b.width,
+		b.height,
+		opts,
 	);
-	const tip = vec(b.x + shift.x + b.width / 2, b.y + shift.y - margin);
-	const dir = subVec(tip, start);
-	const len = lengthVec(dir);
-	const head = 6;
-	const ratio = len > 0 ? (len - head) / len : 0;
-	const shaftEnd = addVec(start, scaleVec(dir, ratio));
-	const unit = len === 0 ? vec(0, 0) : scaleVec(dir, 1 / len);
-	const perp = perpVec(unit);
-	const w = head * 0.6;
-	const left = addVec(shaftEnd, scaleVec(perp, w * 0.5));
-	const right = addVec(shaftEnd, scaleVec(perp, -w * 0.5));
 
-	const attrs = getAttrs(n);
+	const stroke = n.stroke ?? "black";
+	const sw = n.strokeWidth ?? 3;
+	const endAngleAsDegrees = ae * (180 / Math.PI);
+	const points = [
+		[0, -2 * sw],
+		[4 * sw, 0],
+		[0, 2 * sw],
+	]
+		.map((p) => p.join(","))
+		.join(" ");
 
-	const line: LineElement = {
-		type: "line",
+	const elements: SvgElement[] = [];
+	if (opts.start) {
+		elements.push({
+			type: "circle",
+			cx: sx,
+			cy: sy,
+			r: (4 / 3) * sw,
+			fill: stroke,
+		});
+	}
+	elements.push({
+		type: "path",
 		id,
-		x1: start.x,
-		y1: start.y,
-		x2: shaftEnd.x,
-		y2: shaftEnd.y,
-		...attrs,
-	};
-
-	const poly: PolygonElement = {
+		d: `M${sx},${sy} Q${cx},${cy} ${ex},${ey}`,
+		fill: "none",
+		stroke,
+		strokeWidth: sw,
+	});
+	elements.push({
 		type: "polygon",
-		points: `${tip.x},${tip.y} ${left.x},${left.y} ${right.x},${right.y}`,
-		...attrs,
-	};
-
-	return [line, poly];
+		points,
+		transform: `translate(${ex},${ey}) rotate(${endAngleAsDegrees})`,
+		fill: stroke,
+	});
+	return elements;
 }
 
 // Main function: convert layout to SVG AST
@@ -257,25 +406,36 @@ export function layoutToAst(
 	// content with a positive minimum would sit outside the viewport.
 	const offset = vec(-min.x + margin, -min.y + margin);
 
-	const children: SvgElement[] = [];
+	// Elements grouped per node so multi-element marks (arrows) sort together
+	const groups: { zOrder: number; elements: SvgElement[] }[] = [];
 
 	for (const [id, box] of Object.entries(layout)) {
 		const n = byId.get(id);
 		if (!n?.type) continue;
 
+		let elements: SvgElement[] | undefined;
 		if (n.type === "circle") {
-			children.push(buildCircle(id, box, n, offset));
+			elements = [buildCircle(id, box, n, offset)];
 		} else if (n.type === "text") {
-			children.push(buildText(id, box, n, offset));
+			elements = [buildText(id, box, n, offset)];
+		} else if (n.type === "image") {
+			elements = [buildImage(id, box, n, offset)];
+		} else if (n.type === "line") {
+			const line = buildLine(id, n, layout, offset);
+			elements = line ? [line] : undefined;
 		} else if (n.type === "arrow") {
-			const arrowElements = buildArrow(id, n, layout, offset);
-			if (arrowElements) {
-				children.push(...arrowElements);
-			}
+			elements = buildArrow(id, n, layout, offset);
 		} else {
-			children.push(buildRect(id, box, n, offset));
+			elements = [buildRect(id, box, n, offset)];
 		}
+		if (elements) groups.push({ zOrder: n.zOrder ?? 0, elements });
 	}
+
+	// Stable sort by zOrder: higher paints later (on top), matching Bluefish
+	const children = groups
+		.map((g, i) => ({ ...g, i }))
+		.sort((a, b) => a.zOrder - b.zOrder || a.i - b.i)
+		.flatMap((g) => g.elements);
 
 	const width = max.x - min.x + margin * 2;
 	const height = max.y - min.y + margin * 2;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       ajv:
         specifier: ^8.20.0
         version: 8.20.0
+      perfect-arrows:
+        specifier: ^0.3.7
+        version: 0.3.7
     devDependencies:
       '@types/node':
         specifier: ^26.1.1


### PR DESCRIPTION
Closes every real gap from PARITY.md, each verified against real Bluefish with new fixtures (parity suite: 14 → 24 tests, all passing).

| Gap | Approach |
|---|---|
| **zOrder** | prop on every node, stable sort in `layoutToAst` (Bluefish sorts per parent — nuance documented) |
| **Image** | rect-like layout, paints `<image href>` |
| **SVG attr passthrough** | unrecognized string/number props become escaped SVG attributes; `Background rx` from the official tutorial works now |
| **Stack/Distribute `total` modes** | extent ownership (explicit sizes, circle `r`, text measurement count as owned); `total`+`spacing` assigns leftover extent to unowned children — including Bluefish's quirk of not subtracting the gaps; violations land in `warnings` |
| **Line** | endpoint algorithm ported from `line.tsx` (fractional anchors, clamping, center-bias quirk) |
| **Arrow** | adopted `perfect-arrows` (the exact dependency Bluefish uses) with identical defaults; the fixture compares quadratic path coordinates and the rotated polygon head exactly |
| **Circle cx/cy** | center coords accepted alongside top-left x/y; stroke-width default dropped to match Bluefish |

Also: `Distribute` accepts Bluefish's `direction: horizontal/vertical` values, stack/distribute operators take options objects, schema covers the new types/props, and the fuzzer now generates `Image` leaves. PARITY.md statuses updated.

All 112 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)