### PR TITLE
Fix docs routing under GitHub Pages subpath

### DIFF
--- a/packages/docs/src/App.tsx
+++ b/packages/docs/src/App.tsx
@@ -103,7 +103,7 @@ export const pages: Page[] = [
 		],
 	},
 	{
-		path: "/interactive",
+		path: "/interactive/",
 		title: "Interactivity",
 		sections: [
 			{
@@ -129,7 +129,7 @@ export const pages: Page[] = [
 		],
 	},
 	{
-		path: "/diagrams",
+		path: "/diagrams/",
 		title: "Diagrams",
 		sections: [
 			{
@@ -149,7 +149,7 @@ export const pages: Page[] = [
 		],
 	},
 	{
-		path: "/sequence",
+		path: "/sequence/",
 		title: "Sequence Diagram",
 		sections: [
 			{
@@ -168,7 +168,7 @@ export const pages: Page[] = [
 		],
 	},
 	{
-		path: "/packet",
+		path: "/packet/",
 		title: "Packet Diagram",
 		sections: [
 			{
@@ -187,7 +187,7 @@ export const pages: Page[] = [
 		],
 	},
 	{
-		path: "/gitgraph",
+		path: "/gitgraph/",
 		title: "Git Graph",
 		sections: [
 			{
@@ -206,7 +206,7 @@ export const pages: Page[] = [
 		],
 	},
 	{
-		path: "/charts",
+		path: "/charts/",
 		title: "Pie & Venn",
 		sections: [
 			{
@@ -238,7 +238,7 @@ export const pages: Page[] = [
 		],
 	},
 	{
-		path: "/baking-recipe",
+		path: "/baking-recipe/",
 		title: "Baking Recipe",
 		sections: [
 			{
@@ -251,7 +251,7 @@ export const pages: Page[] = [
 		],
 	},
 	{
-		path: "/quantum-circuit",
+		path: "/quantum-circuit/",
 		title: "Quantum Circuit",
 		sections: [
 			{
@@ -264,7 +264,7 @@ export const pages: Page[] = [
 		],
 	},
 	{
-		path: "/pulley",
+		path: "/pulley/",
 		title: "Pulley System",
 		sections: [
 			{

--- a/packages/docs/src/main.tsx
+++ b/packages/docs/src/main.tsx
@@ -8,7 +8,11 @@ if (!rootElement) {
 	throw new Error("Root element not found");
 }
 
-const router = createBrowserRouter(routes);
+// react-router's basename tracks Vite's base so routing works under a
+// subpath (e.g. /<repo>/ on GitHub Pages).
+const router = createBrowserRouter(routes, {
+	basename: import.meta.env.BASE_URL,
+});
 
 createRoot(rootElement).render(
 	<StrictMode>

--- a/packages/docs/src/ssg-main.tsx
+++ b/packages/docs/src/ssg-main.tsx
@@ -8,7 +8,11 @@ if (!rootElement) {
 	throw new Error("Root element not found");
 }
 
-const router = createBrowserRouter(routes);
+// react-router's basename tracks Vite's base so hydration lines up with
+// the statically rendered pages served under a subpath.
+const router = createBrowserRouter(routes, {
+	basename: import.meta.env.BASE_URL,
+});
 
 hydrateRoot(
 	rootElement,

--- a/packages/docs/tests/basic.spec.ts
+++ b/packages/docs/tests/basic.spec.ts
@@ -63,7 +63,7 @@ test("Canvas renders SVG elements with console diagnostics", async ({
 });
 
 test("arrows render as straight lines with polygon heads", async ({ page }) => {
-	await page.goto("http://localhost:5173/diagrams");
+	await page.goto("http://localhost:5173/diagrams/");
 	await page.waitForTimeout(2000);
 
 	// The Full Planet Example draws arrows between labels and planets
@@ -76,15 +76,15 @@ test("arrows render as straight lines with polygon heads", async ({ page }) => {
 test("every example shows its source code on every page", async ({ page }) => {
 	const routes = [
 		"/",
-		"/interactive",
-		"/diagrams",
-		"/sequence",
-		"/packet",
-		"/gitgraph",
-		"/charts",
-		"/baking-recipe",
-		"/quantum-circuit",
-		"/pulley",
+		"/interactive/",
+		"/diagrams/",
+		"/sequence/",
+		"/packet/",
+		"/gitgraph/",
+		"/charts/",
+		"/baking-recipe/",
+		"/quantum-circuit/",
+		"/pulley/",
 	];
 	for (const route of routes) {
 		await page.goto(`http://localhost:5173${route}`);
@@ -99,7 +99,7 @@ test("every example shows its source code on every page", async ({ page }) => {
 });
 
 test("planet label dropdown retargets the refs", async ({ page }) => {
-	await page.goto("http://localhost:5173/diagrams");
+	await page.goto("http://localhost:5173/diagrams/");
 	await page.waitForTimeout(2000);
 
 	const label = page.locator('svg text[id="label"]');
@@ -116,19 +116,19 @@ test("the Bluefish gallery examples render on their pages", async ({
 	page,
 }) => {
 	// Baking recipe: the table cell borders exist and the title cell spans them
-	await page.goto("http://localhost:5173/baking-recipe");
+	await page.goto("http://localhost:5173/baking-recipe/");
 	await page.waitForTimeout(1500);
 	expect(await page.locator('svg rect[id="cb12"]').count()).toBe(1);
 	expect(await page.locator('svg rect[id="recipeTable"]').count()).toBe(1);
 
 	// Quantum circuit: control-dot circles and connecting lines
-	await page.goto("http://localhost:5173/quantum-circuit");
+	await page.goto("http://localhost:5173/quantum-circuit/");
 	await page.waitForTimeout(1500);
 	expect(await page.locator('svg circle[id="c1"]').count()).toBe(1);
 	expect(await page.locator('svg circle[id="c2"]').count()).toBe(1);
 
 	// Pulley: trapezoid weights are paths, ropes are lines
-	await page.goto("http://localhost:5173/pulley");
+	await page.goto("http://localhost:5173/pulley/");
 	await page.waitForTimeout(1500);
 	expect(await page.locator('svg path[d*="M 10,0"]').count()).toBe(2);
 	expect(await page.locator('svg line[id="l6copy"]').count()).toBe(1);
@@ -137,7 +137,7 @@ test("the Bluefish gallery examples render on their pages", async ({
 test("the sequence diagram renders lifelines, arrows and activations", async ({
 	page,
 }) => {
-	await page.goto("http://localhost:5173/sequence");
+	await page.goto("http://localhost:5173/sequence/");
 	await page.waitForTimeout(1500);
 
 	// lifelines across the three diagrams: 3 (http) + 3 (oauth) + 2 (tcp)
@@ -180,7 +180,7 @@ test("the sequence diagram renders lifelines, arrows and activations", async ({
 test("the packet diagram sizes fields by bits and fills rests", async ({
 	page,
 }) => {
-	await page.goto("http://localhost:5173/packet");
+	await page.goto("http://localhost:5173/packet/");
 	await page.waitForTimeout(1500);
 
 	const tcp = page.locator("svg").first();
@@ -202,7 +202,7 @@ test("the packet diagram sizes fields by bits and fills rests", async ({
 });
 
 test("the git graph renders lanes, edges, and the merge", async ({ page }) => {
-	await page.goto("http://localhost:5173/gitgraph");
+	await page.goto("http://localhost:5173/gitgraph/");
 	await page.waitForTimeout(1500);
 
 	// 7 commit circles in each of the two directions
@@ -262,7 +262,7 @@ test("the color-constraint examples work", async ({ page }) => {
 test("pie chart: slices are arcs auto-colored, legend matches via SameColor", async ({
 	page,
 }) => {
-	await page.goto("http://localhost:5173/charts");
+	await page.goto("http://localhost:5173/charts/");
 	await page.waitForTimeout(1500);
 	const pie = page.locator("section", { hasText: "Pie charts from data" });
 	const svg = pie.locator("svg").first();
@@ -287,7 +287,7 @@ test("pie chart: slices are arcs auto-colored, legend matches via SameColor", as
 test("venn: overlapping translucent circles with distinct fills", async ({
 	page,
 }) => {
-	await page.goto("http://localhost:5173/charts");
+	await page.goto("http://localhost:5173/charts/");
 	await page.waitForTimeout(1500);
 	const three = page
 		.locator("section", { hasText: "Venn diagrams from data" })
@@ -307,7 +307,7 @@ test("venn: overlapping translucent circles with distinct fills", async ({
 test("pie chart hover darkens the slice and lightens the rest", async ({
 	page,
 }) => {
-	await page.goto("http://localhost:5173/charts");
+	await page.goto("http://localhost:5173/charts/");
 	await page.waitForTimeout(1500);
 	const pie = page
 		.locator("section", { hasText: "Pie charts from data" })

--- a/packages/docs/tests/context.spec.ts
+++ b/packages/docs/tests/context.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from "@playwright/test";
 test("Context forwarding works - theme changes update circle colors", async ({
 	page,
 }) => {
-	await page.goto("http://localhost:5173/interactive");
+	await page.goto("http://localhost:5173/interactive/");
 
 	// Wait for the context canvas to be visible
 	const canvas = page.locator('[data-testid="context-canvas"]');
@@ -46,7 +46,7 @@ test("Context forwarding works - theme changes update circle colors", async ({
 test("Context forwarding works - size scale changes circle radius", async ({
 	page,
 }) => {
-	await page.goto("http://localhost:5173/interactive");
+	await page.goto("http://localhost:5173/interactive/");
 
 	// Wait for the context canvas
 	const canvas = page.locator('[data-testid="context-canvas"]');
@@ -90,7 +90,7 @@ test("Context forwarding works - size scale changes circle radius", async ({
 test("Context forwarding works - multiple contexts update independently", async ({
 	page,
 }) => {
-	await page.goto("http://localhost:5173/interactive");
+	await page.goto("http://localhost:5173/interactive/");
 
 	const canvas = page.locator('[data-testid="context-canvas"]');
 	await expect(canvas).toBeVisible();


### PR DESCRIPTION
The deployed docs site loaded then errored (React #418 + 404): the client react-router had no `basename`, so under `/modular-svg/` it 404'd and the client tree mismatched the prerendered HTML.

Fix matches capra-fagradar's working SSG setup:
- client `createBrowserRouter` gets `basename: import.meta.env.BASE_URL` (main + ssg-main)
- route/nav paths are trailing-slash so they match what static hosting serves (directory index → trailing slash)

Verified in a real browser against a `base=/modular-svg/` preview: deep routes hydrate and render, client nav resolves under the base, zero errors. Dev e2e (15) still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)