### PR TITLE
SSG: render nav hrefs with the base path

### DIFF
--- a/packages/docs/ssg-for-vite.tsx
+++ b/packages/docs/ssg-for-vite.tsx
@@ -32,12 +32,17 @@ const routesToPaths = (routes, parentRoute = "") => {
 };
 
 const renderHtml = async (path, routes, mainScript) => {
-	const { query, dataRoutes } = createStaticHandler(routes);
+	// Render with the same basename the client hydrates with (Vite's base),
+	// so NavLink hrefs include the base and match the client after hydration
+	// (otherwise opening a nav link in a new tab would drop the base path).
+	const basename = import.meta.env.BASE_URL;
+	const baseNoSlash = basename.replace(/\/+$/, "");
+	const { query, dataRoutes } = createStaticHandler(routes, { basename });
 
-	const url = new URL(path, "http://localhost/");
+	const url = new URL("http://localhost/");
 	url.search = "";
 	url.hash = "";
-	url.pathname = path;
+	url.pathname = baseNoSlash + path;
 
 	const context = await query(
 		new Request(url.href, {


### PR DESCRIPTION
The prerendered nav `href`s were base-less (`/gitgraph/`), so opening a nav link in a new tab under a subpath dropped the base and 404'd. Now the static handler renders with the same `basename` the client uses (and the queried path is base-prefixed so route matching still works), producing based hrefs (`/modular-svg/gitgraph/`) that match the client after hydration.

Verified against a `base=/modular-svg/` preview: pages hydrate, nav hrefs carry the base, client nav resolves, no errors; root deploy unaffected; dev e2e (15) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)