### PR TITLE
Rename the Canvas component to Graphic

### DIFF
--- a/packages/bluefish-parity/PARITY.md
+++ b/packages/bluefish-parity/PARITY.md
@@ -54,7 +54,7 @@ Status legend:
 | **Layout / LayoutFunction** | custom layout escape hatches (function props) | custom `LayoutOperator` via `solveLayout` API; the span-copy idiom (copy one axis' position+extent) has a JSON `Span` relation (fixture: brownie cell borders) | ➖ escape hatch / ✅ span idiom |
 | **Ownership errors** | typed errors (DimAlreadyOwned w/ provenance, DimUnowned, NaN, …) — but currently soft (`console.warn`) | `JsonScene.warnings` for double hard ownership; hard throws for dup ids / unknown refs | ✅ comparable |
 | **Reactivity / control flow** | Solid signals; For/Show/Index/Switch/Match (hyperscript) | react package (state → re-render); JSON is data | ➖ framework-specific |
-| **Interactivity** | signals driving props; no dedicated API | react Canvas event handlers | ➖ different mechanism |
+| **Interactivity** | signals driving props; no dedicated API | react Graphic event handlers | ➖ different mechanism |
 | **debug / window.bluefish / DEBUG-name breakpoints** | scenegraph dump, debugger triggers | — | ➖ |
 
 ## Gallery compliance

--- a/packages/docs/src/App.tsx
+++ b/packages/docs/src/App.tsx
@@ -75,7 +75,7 @@ export const pages: Page[] = [
 			{
 				title: "Custom Styling",
 				description:
-					"Canvas accepts standard div props like className and style",
+					"Graphic accepts standard div props like className and style",
 				code: customStylingCode,
 				element: <CustomStyling />,
 			},
@@ -109,7 +109,7 @@ export const pages: Page[] = [
 			{
 				title: "Interactive with React State",
 				description:
-					"Adjust the controls to see the layout update in real-time - including the margin the Canvas reserves around the content",
+					"Adjust the controls to see the layout update in real-time - including the margin the Graphic reserves around the content",
 				code: interactiveStateCode,
 				element: <InteractiveState />,
 			},
@@ -122,7 +122,7 @@ export const pages: Page[] = [
 			{
 				title: "React Context Forwarding",
 				description:
-					"React contexts automatically flow into Canvas children - no special setup required",
+					"React contexts automatically flow into Graphic children - no special setup required",
 				code: contextForwardingCode,
 				element: <ContextForwarding />,
 			},

--- a/packages/docs/src/examples/BakingRecipe.tsx
+++ b/packages/docs/src/examples/BakingRecipe.tsx
@@ -1,4 +1,4 @@
-import { Canvas } from "@modular-svg/react";
+import { Graphic } from "@modular-svg/react";
 import * as React from "react";
 
 // The span relation's JSX tag collides with HTML <span> in TypeScript's
@@ -51,7 +51,7 @@ const rows = [0, 1, 2, 3, 4, 5].map((i) => `col0-row${i}`);
 
 export function BakingRecipe() {
 	return (
-		<Canvas
+		<Graphic
 			style={{
 				border: "1px solid #ddd",
 				borderRadius: "8px",
@@ -270,6 +270,6 @@ export function BakingRecipe() {
 					<ref target="recipeTable" />
 				</stackV>
 			</group>
-		</Canvas>
+		</Graphic>
 	);
 }

--- a/packages/docs/src/examples/BarChart.tsx
+++ b/packages/docs/src/examples/BarChart.tsx
@@ -1,4 +1,4 @@
-import { Canvas } from "@modular-svg/react";
+import { Graphic } from "@modular-svg/react";
 import { useState } from "react";
 
 const data = [
@@ -63,7 +63,7 @@ export function BarChart() {
 					/>
 				</label>
 			</div>
-			<Canvas
+			<Graphic
 				style={{
 					border: "1px solid #ddd",
 					borderRadius: "8px",
@@ -107,7 +107,7 @@ export function BarChart() {
 						<ref target={peak.id} />
 					</arrow>
 				</group>
-			</Canvas>
+			</Graphic>
 		</div>
 	);
 }

--- a/packages/docs/src/examples/ContextForwarding.tsx
+++ b/packages/docs/src/examples/ContextForwarding.tsx
@@ -1,4 +1,4 @@
-import { Canvas } from "@modular-svg/react";
+import { Graphic } from "@modular-svg/react";
 import { createContext, useContext, useState } from "react";
 
 const ThemeContext = createContext<"light" | "dark">("light");
@@ -56,7 +56,7 @@ export function ContextForwarding() {
 							/>
 						</label>
 					</div>
-					<Canvas
+					<Graphic
 						style={{
 							border: "1px solid #ddd",
 							borderRadius: "8px",
@@ -70,7 +70,7 @@ export function ContextForwarding() {
 							<ThemedCircle />
 							<ThemedCircle />
 						</stackH>
-					</Canvas>
+					</Graphic>
 				</div>
 			</SizeScaleContext.Provider>
 		</ThemeContext.Provider>

--- a/packages/docs/src/examples/ContrastExample.tsx
+++ b/packages/docs/src/examples/ContrastExample.tsx
@@ -1,4 +1,4 @@
-import { Canvas } from "@modular-svg/react";
+import { Graphic } from "@modular-svg/react";
 import { useState } from "react";
 
 // The label has no readable color of its own - Contrast adjusts its
@@ -18,7 +18,7 @@ export function ContrastExample() {
 					style={{ marginLeft: "1rem", verticalAlign: "middle" }}
 				/>
 			</label>
-			<Canvas
+			<Graphic
 				style={{
 					border: "1px solid #ddd",
 					borderRadius: "8px",
@@ -37,7 +37,7 @@ export function ContrastExample() {
 						<ref target="box" />
 					</contrast>
 				</group>
-			</Canvas>
+			</Graphic>
 		</div>
 	);
 }

--- a/packages/docs/src/examples/CustomStyling.tsx
+++ b/packages/docs/src/examples/CustomStyling.tsx
@@ -1,8 +1,8 @@
-import { Canvas } from "@modular-svg/react";
+import { Graphic } from "@modular-svg/react";
 
 export function CustomStyling() {
 	return (
-		<Canvas
+		<Graphic
 			className="custom-canvas"
 			style={{
 				border: "3px solid #333",
@@ -18,6 +18,6 @@ export function CustomStyling() {
 				<circle r={20} fill="indigo" />
 				<rect width={60} height={40} fill="tomato" />
 			</stackV>
-		</Canvas>
+		</Graphic>
 	);
 }

--- a/packages/docs/src/examples/DistinctColorsExample.tsx
+++ b/packages/docs/src/examples/DistinctColorsExample.tsx
@@ -1,4 +1,4 @@
-import { Canvas } from "@modular-svg/react";
+import { Graphic } from "@modular-svg/react";
 import { useState } from "react";
 
 // A row of circles with no fill. DistinctColors spreads their hues evenly
@@ -35,7 +35,7 @@ export function DistinctColorsExample() {
 					/>
 				</label>
 			</div>
-			<Canvas
+			<Graphic
 				style={{
 					border: "1px solid #ddd",
 					borderRadius: "8px",
@@ -55,7 +55,7 @@ export function DistinctColorsExample() {
 						))}
 					</distinctColors>
 				</group>
-			</Canvas>
+			</Graphic>
 		</div>
 	);
 }

--- a/packages/docs/src/examples/EventHandlers.tsx
+++ b/packages/docs/src/examples/EventHandlers.tsx
@@ -1,4 +1,4 @@
-import { Canvas } from "@modular-svg/react";
+import { Graphic } from "@modular-svg/react";
 import { useState } from "react";
 
 export function EventHandlers() {
@@ -34,7 +34,7 @@ export function EventHandlers() {
 			<p style={{ color: "#333", fontSize: "14px", marginBottom: "1rem" }}>
 				{clicked ? `You clicked: ${clicked}` : "Click on any circle below"}
 			</p>
-			<Canvas
+			<Graphic
 				style={{
 					border: "1px solid #ddd",
 					borderRadius: "8px",
@@ -58,7 +58,7 @@ export function EventHandlers() {
 						/>
 					))}
 				</stackH>
-			</Canvas>
+			</Graphic>
 		</div>
 	);
 }

--- a/packages/docs/src/examples/GitGraph.tsx
+++ b/packages/docs/src/examples/GitGraph.tsx
@@ -1,4 +1,4 @@
-import { Canvas } from "@modular-svg/react";
+import { Graphic } from "@modular-svg/react";
 import * as React from "react";
 
 export type Branch = { name: string; color?: string };
@@ -93,7 +93,7 @@ export function GitGraph({
 	);
 
 	return (
-		<Canvas
+		<Graphic
 			style={{
 				border: "1px solid #ddd",
 				borderRadius: "8px",
@@ -230,6 +230,6 @@ export function GitGraph({
 					</contrast>
 				))}
 			</group>
-		</Canvas>
+		</Graphic>
 	);
 }

--- a/packages/docs/src/examples/InteractiveState.tsx
+++ b/packages/docs/src/examples/InteractiveState.tsx
@@ -1,4 +1,4 @@
-import { Canvas } from "@modular-svg/react";
+import { Graphic } from "@modular-svg/react";
 import { useState } from "react";
 
 export function InteractiveState() {
@@ -33,7 +33,7 @@ export function InteractiveState() {
 					/>
 				</label>
 				<label style={{ display: "block", marginBottom: "0.5rem" }}>
-					Canvas margin: {margin}px
+					Graphic margin: {margin}px
 					<input
 						type="range"
 						min="0"
@@ -53,7 +53,7 @@ export function InteractiveState() {
 					Show Rectangle
 				</label>
 			</div>
-			<Canvas
+			<Graphic
 				style={{
 					border: "1px solid #ddd",
 					borderRadius: "8px",
@@ -66,7 +66,7 @@ export function InteractiveState() {
 					{showRect && <rect width={radius * 2} height={radius} fill="gold" />}
 					<circle r={radius} fill="cyan" />
 				</stackH>
-			</Canvas>
+			</Graphic>
 		</div>
 	);
 }

--- a/packages/docs/src/examples/PacketDiagram.tsx
+++ b/packages/docs/src/examples/PacketDiagram.tsx
@@ -1,4 +1,4 @@
-import { Canvas } from "@modular-svg/react";
+import { Graphic } from "@modular-svg/react";
 
 export type Field = {
 	name: string;
@@ -70,7 +70,7 @@ export function PacketDiagram({
 	const cellId = (r: number, c: number) => `cell-${r}-${c}`;
 
 	return (
-		<Canvas
+		<Graphic
 			style={{
 				border: "1px solid #ddd",
 				borderRadius: "8px",
@@ -141,6 +141,6 @@ export function PacketDiagram({
 					}),
 				)}
 			</group>
-		</Canvas>
+		</Graphic>
 	);
 }

--- a/packages/docs/src/examples/PieChart.tsx
+++ b/packages/docs/src/examples/PieChart.tsx
@@ -1,4 +1,4 @@
-import { Canvas } from "@modular-svg/react";
+import { Graphic } from "@modular-svg/react";
 import { useState } from "react";
 
 export type Slice = { label: string; value: number };
@@ -41,7 +41,7 @@ export function PieChart({
 	});
 
 	return (
-		<Canvas
+		<Graphic
 			style={{
 				border: "1px solid #ddd",
 				borderRadius: "8px",
@@ -130,6 +130,6 @@ export function PieChart({
 					);
 				})}
 			</group>
-		</Canvas>
+		</Graphic>
 	);
 }

--- a/packages/docs/src/examples/PlanetExample.tsx
+++ b/packages/docs/src/examples/PlanetExample.tsx
@@ -1,4 +1,4 @@
-import { Canvas } from "@modular-svg/react";
+import { Graphic } from "@modular-svg/react";
 import { useState } from "react";
 
 const planets = [
@@ -34,7 +34,7 @@ export function PlanetExample() {
 					))}
 				</select>
 			</label>
-			<Canvas
+			<Graphic
 				style={{
 					border: "1px solid #ddd",
 					borderRadius: "8px",
@@ -68,7 +68,7 @@ export function PlanetExample() {
 						<ref target={target} />
 					</arrow>
 				</group>
-			</Canvas>
+			</Graphic>
 		</div>
 	);
 }

--- a/packages/docs/src/examples/PulleyDiagram.tsx
+++ b/packages/docs/src/examples/PulleyDiagram.tsx
@@ -1,4 +1,4 @@
-import { Canvas } from "@modular-svg/react";
+import { Graphic } from "@modular-svg/react";
 import * as React from "react";
 
 const R = 25;
@@ -71,7 +71,7 @@ function RopeLabel({ id, children }: { id: string; children: string }) {
 
 export function PulleyDiagram() {
 	return (
-		<Canvas
+		<Graphic
 			style={{
 				border: "1px solid #ddd",
 				borderRadius: "8px",
@@ -240,6 +240,6 @@ export function PulleyDiagram() {
 				<Rope id="l0" from="rect" to="B" target={[0.5, 0.5]} />
 				<Rope id="l6copy" from="C" to="w2" source={[0.5, 0.5]} />
 			</group>
-		</Canvas>
+		</Graphic>
 	);
 }

--- a/packages/docs/src/examples/QuantumCircuit.tsx
+++ b/packages/docs/src/examples/QuantumCircuit.tsx
@@ -1,4 +1,4 @@
-import { Canvas } from "@modular-svg/react";
+import { Graphic } from "@modular-svg/react";
 import type * as React from "react";
 
 // One horizontal circuit wire with symbols laid on top of it
@@ -74,7 +74,7 @@ function ControlDot({ id }: { id: string }) {
 
 export function QuantumCircuit() {
 	return (
-		<Canvas
+		<Graphic
 			style={{
 				border: "1px solid #ddd",
 				borderRadius: "8px",
@@ -133,6 +133,6 @@ export function QuantumCircuit() {
 					<ref target="plusDescription" />
 				</background>
 			</group>
-		</Canvas>
+		</Graphic>
 	);
 }

--- a/packages/docs/src/examples/ReactComponents.tsx
+++ b/packages/docs/src/examples/ReactComponents.tsx
@@ -1,4 +1,4 @@
-import { Canvas } from "@modular-svg/react";
+import { Graphic } from "@modular-svg/react";
 
 function ColoredCircle({ color }: { color: string }) {
 	return <circle r={18} fill={color} />;
@@ -6,7 +6,7 @@ function ColoredCircle({ color }: { color: string }) {
 
 export function ReactComponents() {
 	return (
-		<Canvas
+		<Graphic
 			style={{
 				border: "1px solid #ddd",
 				borderRadius: "8px",
@@ -19,6 +19,6 @@ export function ReactComponents() {
 				<ColoredCircle color="green" />
 				<ColoredCircle color="blue" />
 			</stackH>
-		</Canvas>
+		</Graphic>
 	);
 }

--- a/packages/docs/src/examples/SameColorExample.tsx
+++ b/packages/docs/src/examples/SameColorExample.tsx
@@ -1,4 +1,4 @@
-import { Canvas } from "@modular-svg/react";
+import { Graphic } from "@modular-svg/react";
 import { useState } from "react";
 
 // One source swatch defines the color; SameColor copies it onto every
@@ -17,7 +17,7 @@ export function SameColorExample() {
 					style={{ marginLeft: "1rem", verticalAlign: "middle" }}
 				/>
 			</label>
-			<Canvas
+			<Graphic
 				style={{
 					border: "1px solid #ddd",
 					borderRadius: "8px",
@@ -45,7 +45,7 @@ export function SameColorExample() {
 						<ref target="f3" />
 					</sameColor>
 				</group>
-			</Canvas>
+			</Graphic>
 		</div>
 	);
 }

--- a/packages/docs/src/examples/SequenceDiagram.tsx
+++ b/packages/docs/src/examples/SequenceDiagram.tsx
@@ -1,4 +1,4 @@
-import { Canvas } from "@modular-svg/react";
+import { Graphic } from "@modular-svg/react";
 import * as React from "react";
 
 export type Actor = string | { id: string; label: string };
@@ -248,7 +248,7 @@ export function SequenceDiagram({
 	});
 
 	return (
-		<Canvas
+		<Graphic
 			style={{
 				border: "1px solid #ddd",
 				borderRadius: "8px",
@@ -609,6 +609,6 @@ export function SequenceDiagram({
 					);
 				})}
 			</group>
-		</Canvas>
+		</Graphic>
 	);
 }

--- a/packages/docs/src/examples/ShapesAndStacks.tsx
+++ b/packages/docs/src/examples/ShapesAndStacks.tsx
@@ -1,8 +1,8 @@
-import { Canvas } from "@modular-svg/react";
+import { Graphic } from "@modular-svg/react";
 
 export function ShapesAndStacks() {
 	return (
-		<Canvas
+		<Graphic
 			style={{
 				border: "1px solid #ddd",
 				borderRadius: "8px",
@@ -21,6 +21,6 @@ export function ShapesAndStacks() {
 					<rect width={30} height={30} fill="mediumpurple" />
 				</stackH>
 			</stackV>
-		</Canvas>
+		</Graphic>
 	);
 }

--- a/packages/docs/src/examples/VennDiagram.tsx
+++ b/packages/docs/src/examples/VennDiagram.tsx
@@ -1,4 +1,4 @@
-import { Canvas } from "@modular-svg/react";
+import { Graphic } from "@modular-svg/react";
 
 export type VennSet = { label: string };
 
@@ -42,7 +42,7 @@ export function VennDiagram({
 	});
 
 	return (
-		<Canvas
+		<Graphic
 			style={{
 				border: "1px solid #ddd",
 				borderRadius: "8px",
@@ -79,6 +79,6 @@ export function VennDiagram({
 					))}
 				</distinctColors>
 			</group>
-		</Canvas>
+		</Graphic>
 	);
 }

--- a/packages/docs/tests/basic.spec.ts
+++ b/packages/docs/tests/basic.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-test("Canvas renders SVG elements with console diagnostics", async ({
+test("Graphic renders SVG elements with console diagnostics", async ({
 	page,
 }) => {
 	const consoleMessages: string[] = [];
@@ -32,15 +32,15 @@ test("Canvas renders SVG elements with console diagnostics", async ({
 	const circleCount = await page.locator("circle").count();
 	console.log(`Found ${circleCount} circle elements`);
 
-	// Get the first Canvas div
-	const firstCanvas = page
+	// Get the first Graphic div
+	const firstGraphic = page
 		.locator("div")
 		.filter({ has: page.locator("svg") })
 		.first();
-	const hasCanvas = (await firstCanvas.count()) > 0;
+	const hasGraphic = (await firstGraphic.count()) > 0;
 
-	if (!hasCanvas) {
-		console.log("\n⚠️ No Canvas with SVG found!");
+	if (!hasGraphic) {
+		console.log("\n⚠️ No Graphic with SVG found!");
 		console.log("Empty div count:", await page.locator("div").count());
 	}
 

--- a/packages/modular-svg-react/src/Graphic.tsx
+++ b/packages/modular-svg-react/src/Graphic.tsx
@@ -12,7 +12,7 @@ import {
 	type ReconcilerRoot,
 } from "./reconciler";
 
-export interface CanvasProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface GraphicProps extends React.HTMLAttributes<HTMLDivElement> {
 	children?: React.ReactNode;
 	margin?: number;
 	title?: string;
@@ -156,8 +156,8 @@ function SvgElementRenderer({ element }: { element: SvgElement }) {
 	return null;
 }
 
-// Internal Canvas component that uses context bridge
-function CanvasImpl({ children, margin = 0, title, ...props }: CanvasProps) {
+// Internal Graphic component that uses context bridge
+function GraphicImpl({ children, margin = 0, title, ...props }: GraphicProps) {
 	const rootRef = React.useRef<ReconcilerRoot | null>(null);
 	const [ast, setAst] = React.useState<SvgDocument | null>(null);
 
@@ -225,12 +225,12 @@ function CanvasImpl({ children, margin = 0, title, ...props }: CanvasProps) {
 	);
 }
 
-// Public Canvas component that wraps CanvasImpl with FiberProvider
+// Public Graphic component that wraps GraphicImpl with FiberProvider
 // This enables context forwarding from react-dom to our custom reconciler
-export function Canvas(props: CanvasProps) {
+export function Graphic(props: GraphicProps) {
 	return (
 		<FiberProvider>
-			<CanvasImpl {...props} />
+			<GraphicImpl {...props} />
 		</FiberProvider>
 	);
 }

--- a/packages/modular-svg-react/src/__tests__/Graphic.test.tsx
+++ b/packages/modular-svg-react/src/__tests__/Graphic.test.tsx
@@ -1,18 +1,18 @@
 import { render, waitFor } from "@testing-library/react";
 import * as React from "react";
 import { describe, expect, it } from "vitest";
-import { Canvas } from "../Canvas";
+import { Graphic } from "../Graphic";
 
 // Extend JSX intrinsic elements for testing
 // Using module augmentation to extend, not replace React's types
 
-describe("Canvas component", () => {
+describe("Graphic component", () => {
 	describe("Basic Rendering", () => {
-		it("should render Canvas component", async () => {
+		it("should render Graphic component", async () => {
 			const { container } = render(
-				<Canvas>
+				<Graphic>
 					<circle r={10} />
-				</Canvas>,
+				</Graphic>,
 			);
 
 			// Should create a div container
@@ -20,11 +20,11 @@ describe("Canvas component", () => {
 			expect(container.firstChild?.nodeName).toBe("DIV");
 		});
 
-		it("should render SVG inside Canvas", async () => {
+		it("should render SVG inside Graphic", async () => {
 			const { container } = render(
-				<Canvas>
+				<Graphic>
 					<circle r={10} fill="red" />
-				</Canvas>,
+				</Graphic>,
 			);
 
 			await waitFor(() => {
@@ -35,9 +35,9 @@ describe("Canvas component", () => {
 
 		it("should render circle element in SVG", async () => {
 			const { container } = render(
-				<Canvas>
+				<Graphic>
 					<circle r={10} fill="red" />
-				</Canvas>,
+				</Graphic>,
 			);
 
 			await waitFor(() => {
@@ -50,12 +50,12 @@ describe("Canvas component", () => {
 
 		it("should render multiple elements", async () => {
 			const { container } = render(
-				<Canvas>
+				<Graphic>
 					<stackH spacing={10}>
 						<circle r={5} fill="red" />
 						<circle r={8} fill="blue" />
 					</stackH>
-				</Canvas>,
+				</Graphic>,
 			);
 
 			await waitFor(() => {
@@ -68,9 +68,9 @@ describe("Canvas component", () => {
 	describe("Props", () => {
 		it("should accept margin prop", async () => {
 			const { container } = render(
-				<Canvas margin={20}>
+				<Graphic margin={20}>
 					<circle r={10} />
-				</Canvas>,
+				</Graphic>,
 			);
 
 			await waitFor(() => {
@@ -81,9 +81,9 @@ describe("Canvas component", () => {
 
 		it("should accept className prop", () => {
 			const { container } = render(
-				<Canvas className="my-canvas">
+				<Graphic className="my-canvas">
 					<circle r={10} />
-				</Canvas>,
+				</Graphic>,
 			);
 
 			const div = container.firstChild as HTMLElement;
@@ -92,9 +92,9 @@ describe("Canvas component", () => {
 
 		it("should accept style prop", () => {
 			const { container } = render(
-				<Canvas style={{ width: "500px", height: "300px" }}>
+				<Graphic style={{ width: "500px", height: "300px" }}>
 					<circle r={10} />
-				</Canvas>,
+				</Graphic>,
 			);
 
 			const div = container.firstChild as HTMLElement;
@@ -115,9 +115,9 @@ describe("Canvas component", () => {
 
 			render(
 				<ThemeContext.Provider value="dark">
-					<Canvas>
+					<Graphic>
 						<ThemedCircle />
-					</Canvas>
+					</Graphic>
 				</ThemeContext.Provider>,
 			);
 
@@ -142,9 +142,9 @@ describe("Canvas component", () => {
 			render(
 				<ThemeContext.Provider value="dark">
 					<SizeContext.Provider value={20}>
-						<Canvas>
+						<Graphic>
 							<Component />
-						</Canvas>
+						</Graphic>
 					</SizeContext.Provider>
 				</ThemeContext.Provider>,
 			);
@@ -166,9 +166,9 @@ describe("Canvas component", () => {
 			function App({ size }: { size: number }) {
 				return (
 					<SizeContext.Provider value={size}>
-						<Canvas>
+						<Graphic>
 							<DynamicCircle />
-						</Canvas>
+						</Graphic>
 					</SizeContext.Provider>
 				);
 			}
@@ -193,9 +193,9 @@ describe("Canvas component", () => {
 		it("should re-render when children change", async () => {
 			function App({ radius }: { radius: number }) {
 				return (
-					<Canvas>
+					<Graphic>
 						<circle r={radius} />
-					</Canvas>
+					</Graphic>
 				);
 			}
 
@@ -217,9 +217,9 @@ describe("Canvas component", () => {
 		it("should update SVG when props change", async () => {
 			function App({ fill }: { fill: string }) {
 				return (
-					<Canvas>
+					<Graphic>
 						<circle r={10} fill={fill} />
-					</Canvas>
+					</Graphic>
 				);
 			}
 
@@ -242,9 +242,9 @@ describe("Canvas component", () => {
 	describe("Cleanup", () => {
 		it("should cleanup on unmount", async () => {
 			const { container, unmount } = render(
-				<Canvas>
+				<Graphic>
 					<circle r={10} />
-				</Canvas>,
+				</Graphic>,
 			);
 
 			await waitFor(() => {
@@ -261,7 +261,7 @@ describe("Canvas component", () => {
 	describe("Complex Scenes", () => {
 		it("should render complex nested layout", async () => {
 			const { container } = render(
-				<Canvas margin={10}>
+				<Graphic margin={10}>
 					<stackV spacing={15}>
 						<stackH spacing={10}>
 							<circle r={15} fill="red" />
@@ -269,7 +269,7 @@ describe("Canvas component", () => {
 						</stackH>
 						<circle r={10} fill="green" />
 					</stackV>
-				</Canvas>,
+				</Graphic>,
 			);
 
 			await waitFor(() => {
@@ -278,18 +278,18 @@ describe("Canvas component", () => {
 			});
 		});
 
-		it("should handle React components inside Canvas", async () => {
+		it("should handle React components inside Graphic", async () => {
 			function CustomShape({ color }: { color: string }) {
 				return <circle r={10} fill={color} />;
 			}
 
 			const { container } = render(
-				<Canvas>
+				<Graphic>
 					<stackH>
 						<CustomShape color="red" />
 						<CustomShape color="blue" />
 					</stackH>
-				</Canvas>,
+				</Graphic>,
 			);
 
 			await waitFor(() => {
@@ -302,14 +302,14 @@ describe("Canvas component", () => {
 	describe("Arrow rendering", () => {
 		it("renders arrows as a straight line with a polygon head", async () => {
 			const { container } = render(
-				<Canvas>
+				<Graphic>
 					<rect key="a" width={40} height={30} />
 					<rect key="b" x={120} y={90} width={40} height={30} />
 					<arrow key="arr">
 						<ref target="a" />
 						<ref target="b" />
 					</arrow>
-				</Canvas>,
+				</Graphic>,
 			);
 
 			await waitFor(() => {
@@ -324,7 +324,7 @@ describe("Canvas component", () => {
 	describe("Full planet feature set (text, background, align, distribute, ref, arrow)", () => {
 		it("renders every relation from the original JSON example via JSX", async () => {
 			const { container } = render(
-				<Canvas>
+				<Graphic>
 					<background key="bg" padding={20}>
 						<stackH spacing={50}>
 							<circle key="mercury" r={15} />
@@ -344,7 +344,7 @@ describe("Canvas component", () => {
 						<ref target="label" />
 						<ref target="mercury" />
 					</arrow>
-				</Canvas>,
+				</Graphic>,
 			);
 
 			await waitFor(() => {

--- a/packages/modular-svg-react/src/index.ts
+++ b/packages/modular-svg-react/src/index.ts
@@ -1,12 +1,12 @@
 // Main exports for @modular-svg/react
 
 // Re-export FiberProvider for advanced use cases
-// Note: Canvas includes FiberProvider internally, so you don't need to wrap your app with it
-// Only export this for users who want to use the reconciler directly without Canvas
+// Note: Graphic includes FiberProvider internally, so you don't need to wrap your app with it
+// Only export this for users who want to use the reconciler directly without Graphic
 export { FiberProvider } from "its-fine";
-// Canvas component - automatically includes context forwarding via its-fine
-export type { CanvasProps } from "./Canvas";
-export { Canvas } from "./Canvas";
+// Graphic component - automatically includes context forwarding via its-fine
+export type { GraphicProps } from "./Graphic";
+export { Graphic } from "./Graphic";
 // Reconciler exports for advanced usage and testing
 export type { ReconcilerRoot } from "./reconciler";
 export { act, createRoot } from "./reconciler";


### PR DESCRIPTION
`Canvas` suggested the browser `<canvas>` element, which this component has nothing to do with — it renders an `<svg>`. Mechanical rename:

- react package: `Canvas` → `Graphic`, `CanvasProps` → `GraphicProps`, `Canvas.tsx` → `Graphic.tsx` (+ its test)
- every docs example's import/usage, section descriptions, and the parity-matrix note

The browser `HTMLCanvasElement` in the Bluefish text-measurement shim is untouched. Verified: typecheck, lint, 130 unit tests, 15 docs e2e, and the SSG build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)